### PR TITLE
ci: add reusable workflows

### DIFF
--- a/.github/workflows/ArtifactCleanUp.yml
+++ b/.github/workflows/ArtifactCleanUp.yml
@@ -1,0 +1,34 @@
+name: ArtifactCleanUp
+
+on:
+  workflow_call:
+    inputs:
+      package:
+        description: 'Artifacts to be removed on not tagged runs.'
+        required: true
+        type: string
+      remaining:
+        description: 'Artifacts to be removed unconditionally.'
+        required: false
+        default: ''
+        type: string
+
+jobs:
+
+  ArtifactCleanUp:
+    name: 🗑️ Artifact Cleanup
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: 🗑️ Delete package Artifacts
+        if: ${{ ! startsWith(github.ref, 'refs/tags') }}
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ${{ inputs.package }}
+
+      - name: 🗑️ Delete remaining Artifacts
+        if: ${{ inputs.remaining != '' }}
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ${{ inputs.remaining }}

--- a/.github/workflows/BuildTheDocs.yml
+++ b/.github/workflows/BuildTheDocs.yml
@@ -1,0 +1,31 @@
+name: Documentation
+
+on:
+  workflow_call:
+    inputs:
+      artifact:
+        description: 'Name of the documentation artifact.'
+        required: true
+        type: string
+
+jobs:
+
+  BuildTheDocs:
+    name: 📓 Run BuildTheDocs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: 🛳️ Build documentation
+        uses: buildthedocs/btd@v0
+        with:
+          skip-deploy: true
+
+      - name: 📤 Upload 'documentation' artifacts
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ inputs.artifact }}
+          path: doc/_build/html
+          retention-days: 7

--- a/.github/workflows/BuildTheDocs.yml
+++ b/.github/workflows/BuildTheDocs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: ⏬ Checkout repository
         uses: actions/checkout@v2
 
       - name: 🛳️ Build documentation

--- a/.github/workflows/BuildTheDocs.yml
+++ b/.github/workflows/BuildTheDocs.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           name: ${{ inputs.artifact }}
           path: doc/_build/html
-          retention-days: 7
+          retention-days: 1

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -3,7 +3,7 @@ name: Coverage Collection
 on:
   workflow_call:
     inputs:
-      pyver:
+      python_version:
         description: 'Python version.'
         required: false
         default: '3.10'
@@ -20,17 +20,17 @@ on:
 jobs:
 
   Coverage:
-    name: 📈 Collect Coverage Data using Python ${{ inputs.pyver }}
+    name: 📈 Collect Coverage Data using Python ${{ inputs.python_version }}
     runs-on: ubuntu-latest
 
     steps:
       - name: ⏬ Checkout repository
         uses: actions/checkout@v2
 
-      - name: 🐍 Setup Python ${{ inputs.pyver }}
+      - name: 🐍 Setup Python ${{ inputs.python_version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ inputs.pyver }}
+          python-version: ${{ inputs.python_version }}
 
       - name: 🗂 Install dependencies
         run: |

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: '3.10'
         type: string
+      requirements:
+        description: 'Python dependencies to be installed through pip.'
+        required: false
+        default: '-r tests/requirements.txt'
+        type: string
       artifact:
         description: 'Name of the coverage artifact.'
         required: true
@@ -34,8 +39,8 @@ jobs:
 
       - name: 🗂 Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r tests/requirements.txt
+          python -m pip install -U pip
+          python -m pip install ${{ inputs.requirements }}
 
       - name: Collect coverage
         continue-on-error: true

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -1,0 +1,75 @@
+name: Coverage Collection
+
+on:
+  workflow_call:
+    inputs:
+      pyver:
+        description: 'Python version.'
+        required: false
+        default: '3.10'
+        type: string
+      artifact:
+        description: 'Name of the coverage artifact.'
+        required: true
+        type: string
+    secrets:
+      codacy_token:
+        description: 'Token to push result to codacy.'
+        required: true
+
+jobs:
+
+  Coverage:
+    name: 📈 Collect Coverage Data using Python ${{ inputs.pyver }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⏬ Checkout repository
+        uses: actions/checkout@v2
+
+      - name: 🐍 Setup Python ${{ inputs.pyver }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ inputs.pyver }}
+
+      - name: 🗂 Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/requirements.txt
+
+      - name: Collect coverage
+        continue-on-error: true
+        run: |
+          python -m pytest -rA --cov=.. --cov-config=tests/.coveragerc tests/unit --color=yes
+
+      - name: Convert to cobertura format
+        run: coverage xml
+
+      - name: Convert to HTML format
+        run: |
+          coverage html
+          rm htmlcov/.gitignore
+
+      - name: 📤 Upload 'Coverage Report' artifact
+        continue-on-error: true
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ inputs.artifact }}
+          path: htmlcov
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: 📊 Publish coverage at CodeCov
+        continue-on-error: true
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          env_vars: PYTHON
+
+      - name: 📉 Publish coverage at Codacy
+        continue-on-error: true
+        uses: codacy/codacy-coverage-reporter-action@master
+        with:
+          project-token: ${{ secrets.codacy_token }}
+          coverage-reports: ./coverage.xml

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: 📥 Checkout repository
+      - name: ⏬ Checkout repository
         uses: actions/checkout@v2
 
       - name: 🐍 Setup Python ${{ inputs.python_version }}

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -1,0 +1,48 @@
+name: Package
+
+on:
+  workflow_call:
+    inputs:
+      pyver:
+        description: 'Python version.'
+        required: false
+        default: '3.10'
+        type: string
+      artifact:
+        description: 'Name of the wheel artifact.'
+        required: true
+        type: string
+
+jobs:
+
+  Package:
+    name: 📦 Package in Wheel Format
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v2
+
+      - name: 🐍 Setup Python ${{ inputs.pyver }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ inputs.pyver }}
+
+      - name: 🔧 Install dependencies for packaging and release
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel
+
+      - name: 🔨 Build Python package (source distribution)
+        run: python setup.py sdist
+
+      - name: 🔨 Build Python package (binary distribution - wheel)
+        run: python setup.py bdist_wheel
+
+      - name: 📤 Upload wheel artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ inputs.artifact }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: '3.10'
         type: string
+      requirements:
+        description: 'Python dependencies to be installed through pip.'
+        required: false
+        default: 'wheel'
+        type: string
       artifact:
         description: 'Name of the wheel artifact.'
         required: true
@@ -30,8 +35,8 @@ jobs:
 
       - name: 🔧 Install dependencies for packaging and release
         run: |
-          python -m pip install --upgrade pip
-          pip install wheel
+          python -m pip install -U pip
+          python -m pip install ${{ inputs.requirements }}
 
       - name: 🔨 Build Python package (source distribution)
         run: python setup.py sdist

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -14,14 +14,14 @@ on:
         default: 'wheel'
         type: string
       artifact:
-        description: 'Name of the wheel artifact.'
+        description: 'Name of the package artifact.'
         required: true
         type: string
 
 jobs:
 
   Package:
-    name: 📦 Package in Wheel Format
+    name: 📦 Package in Source and Wheel Format
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -3,7 +3,7 @@ name: Package
 on:
   workflow_call:
     inputs:
-      pyver:
+      python_version:
         description: 'Python version.'
         required: false
         default: '3.10'
@@ -23,10 +23,10 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v2
 
-      - name: 🐍 Setup Python ${{ inputs.pyver }}
+      - name: 🐍 Setup Python ${{ inputs.python_version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ inputs.pyver }}
+          python-version: ${{ inputs.python_version }}
 
       - name: 🔧 Install dependencies for packaging and release
         run: |

--- a/.github/workflows/Params.yml
+++ b/.github/workflows/Params.yml
@@ -43,6 +43,7 @@ jobs:
             'name': name,
             'python_version': '${{ inputs.python_version }}',
             'artifacts': {
+              'unittesting': f'{name}-TestReport',
               'coverage': f'{name}-coverage',
               'typing': f'{name}-typing',
               'package': f'{name}-package',

--- a/.github/workflows/Params.yml
+++ b/.github/workflows/Params.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: '3.10'
         type: string
+      python_version_list:
+        description: 'Space separated list of Python versions to run tests with.'
+        required: false
+        default: '3.6 3.7 3.8 3.9 3.10'
+        type: string
       name:
         description: 'Name of the tool.'
         required: true
@@ -16,6 +21,9 @@ on:
       params:
         description: "Parameters to be used in other jobs."
         value: ${{ jobs.Params.outputs.params }}
+      python_jobs:
+        description: "List of Python versions to be used in the matrix of other jobs."
+        value: ${{ jobs.Params.outputs.python_jobs }}
 
 jobs:
 
@@ -23,9 +31,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       params: ${{ steps.params.outputs.params }}
+      python_jobs: ${{ steps.params.outputs.python_jobs }}
     steps:
 
-      - id: params
+      - name: Generate 'params' and 'python_jobs'
+        id: params
         shell: python
         run: |
           name = '${{ inputs.name }}'
@@ -40,3 +50,20 @@ jobs:
             }
           }
           print(f'::set-output name=params::{params!s}')
+          print("Params:")
+          print(params)
+
+          data = {
+             '3.6': { 'icon': '🔴', 'until': '23.12.2021' },
+             '3.7': { 'icon': '🟠', 'until': '27.06.2023' },
+             '3.8': { 'icon': '🟡', 'until': 'Oct. 2024' },
+             '3.9': { 'icon': '🟢', 'until': 'Oct. 2025' },
+            '3.10': { 'icon': '🟢', 'until': 'Oct. 2026' },
+          }
+          jobs = [
+              {'python': version, 'icon': data[version]['icon']}
+              for version in '${{ inputs.python_version_list }}'.split(' ')
+          ]
+          print(f'::set-output name=python_jobs::{jobs!s}')
+          print("Python jobs:")
+          print(jobs)

--- a/.github/workflows/Params.yml
+++ b/.github/workflows/Params.yml
@@ -1,0 +1,42 @@
+name: Params
+
+on:
+  workflow_call:
+    inputs:
+      pyver:
+        description: 'Python version.'
+        required: false
+        default: '3.10'
+        type: string
+      name:
+        description: 'Name of the tool.'
+        required: true
+        type: string
+    outputs:
+      params:
+        description: "Parameters to be used in other jobs."
+        value: ${{ jobs.Params.outputs.params }}
+
+jobs:
+
+  Params:
+    runs-on: ubuntu-latest
+    outputs:
+      params: ${{ steps.params.outputs.params }}
+    steps:
+
+      - id: params
+        shell: python
+        run: |
+          name = '${{ inputs.name }}'
+          params = {
+            'package': name,
+            'pyver': '${{ inputs.pyver }}',
+            'artifacts': {
+              'coverage': f'{name}-coverage',
+              'typing': f'{name}-typing',
+              'wheel': f'{name}-wheel',
+              'doc': f'{name}-doc',
+            }
+          }
+          print(f'::set-output name=params::{params!s}')

--- a/.github/workflows/Params.yml
+++ b/.github/workflows/Params.yml
@@ -3,7 +3,7 @@ name: Params
 on:
   workflow_call:
     inputs:
-      pyver:
+      python_version:
         description: 'Python version.'
         required: false
         default: '3.10'
@@ -31,7 +31,7 @@ jobs:
           name = '${{ inputs.name }}'
           params = {
             'package': name,
-            'pyver': '${{ inputs.pyver }}',
+            'python_version': '${{ inputs.python_version }}',
             'artifacts': {
               'coverage': f'{name}-coverage',
               'typing': f'{name}-typing',

--- a/.github/workflows/Params.yml
+++ b/.github/workflows/Params.yml
@@ -40,12 +40,12 @@ jobs:
         run: |
           name = '${{ inputs.name }}'
           params = {
-            'package': name,
+            'name': name,
             'python_version': '${{ inputs.python_version }}',
             'artifacts': {
               'coverage': f'{name}-coverage',
               'typing': f'{name}-typing',
-              'wheel': f'{name}-wheel',
+              'package': f'{name}-package',
               'doc': f'{name}-doc',
             }
           }

--- a/.github/workflows/Params.yml
+++ b/.github/workflows/Params.yml
@@ -40,7 +40,6 @@ jobs:
         run: |
           name = '${{ inputs.name }}'
           params = {
-            'name': name,
             'python_version': '${{ inputs.python_version }}',
             'artifacts': {
               'unittesting': f'{name}-TestReport',

--- a/.github/workflows/PublishOnPyPI.yml
+++ b/.github/workflows/PublishOnPyPI.yml
@@ -56,3 +56,8 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: twine upload dist/*.whl
+
+      - name: 🗑️ Delete packaging Artifacts
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ${{ inputs.artifact }}

--- a/.github/workflows/PublishOnPyPI.yml
+++ b/.github/workflows/PublishOnPyPI.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: '3.10'
         type: string
+      requirements:
+        description: 'Python dependencies to be installed through pip.'
+        required: false
+        default: 'wheel twine'
+        type: string
       artifact:
         description: 'Name of the wheel artifact.'
         required: true
@@ -37,15 +42,14 @@ jobs:
 
       - name: ⚙ Install dependencies for packaging and release
         run: |
-          python -m pip install --upgrade pip
-          pip install wheel twine
+          python -m pip install -U pip
+          python -m pip install ${{ inputs.requirements }}
 
       - name: ⤴ Release Python package to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          twine upload dist/*
+        run: twine upload dist/*
 
       - name: 🗑️ Delete packaging Artifacts
         uses: geekyeggo/delete-artifact@v1

--- a/.github/workflows/PublishOnPyPI.yml
+++ b/.github/workflows/PublishOnPyPI.yml
@@ -45,8 +45,14 @@ jobs:
           python -m pip install -U pip
           python -m pip install ${{ inputs.requirements }}
 
-      - name: ⤴ Release Python package to PyPI
+      - name: ⤴ Release Python source package to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: twine upload dist/*
+        run: twine upload dist/*.tar.gz
+
+      - name: ⤴ Release Python wheel package to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: twine upload dist/*.whl

--- a/.github/workflows/PublishOnPyPI.yml
+++ b/.github/workflows/PublishOnPyPI.yml
@@ -14,7 +14,7 @@ on:
         default: 'wheel twine'
         type: string
       artifact:
-        description: 'Name of the wheel artifact.'
+        description: 'Name of the package artifact.'
         required: true
         type: string
     secrets:

--- a/.github/workflows/PublishOnPyPI.yml
+++ b/.github/workflows/PublishOnPyPI.yml
@@ -50,8 +50,3 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: twine upload dist/*
-
-      - name: 🗑️ Delete packaging Artifacts
-        uses: geekyeggo/delete-artifact@v1
-        with:
-          name: ${{ inputs.artifact }}

--- a/.github/workflows/PublishOnPyPI.yml
+++ b/.github/workflows/PublishOnPyPI.yml
@@ -3,7 +3,7 @@ name: Publish on PyPI
 on:
   workflow_call:
     inputs:
-      pyver:
+      python_version:
         description: 'Python version.'
         required: false
         default: '3.10'
@@ -30,10 +30,10 @@ jobs:
           name: ${{ inputs.artifact }}
           path: dist/
 
-      - name: 🐍 Setup Python ${{ inputs.pyver }}
+      - name: 🐍 Setup Python ${{ inputs.python_version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ inputs.pyver }}
+          python-version: ${{ inputs.python_version }}
 
       - name: ⚙ Install dependencies for packaging and release
         run: |

--- a/.github/workflows/PublishOnPyPI.yml
+++ b/.github/workflows/PublishOnPyPI.yml
@@ -1,0 +1,53 @@
+name: Publish on PyPI
+
+on:
+  workflow_call:
+    inputs:
+      pyver:
+        description: 'Python version.'
+        required: false
+        default: '3.10'
+        type: string
+      artifact:
+        description: 'Name of the wheel artifact.'
+        required: true
+        type: string
+    secrets:
+      PYPI_TOKEN:
+        description: "Token for pushing releases to PyPI"
+        required: false
+
+jobs:
+
+  PublishOnPyPI:
+    name: 🚀 Publish to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Download artifacts '${{ inputs.artifact }}' from 'Package' job
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ inputs.artifact }}
+          path: dist/
+
+      - name: 🐍 Setup Python ${{ inputs.pyver }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ inputs.pyver }}
+
+      - name: ⚙ Install dependencies for packaging and release
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel twine
+
+      - name: ⤴ Release Python package to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          twine upload dist/*
+
+      - name: 🗑️ Delete packaging Artifacts
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ${{ inputs.artifact }}

--- a/.github/workflows/PublishToGitHubPages.yml
+++ b/.github/workflows/PublishToGitHubPages.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: ⏬ Checkout repository
         uses: actions/checkout@v2
 
       - name: 📥 Download artifacts '${{ inputs.doc }}' from 'BuildTheDocs' job

--- a/.github/workflows/PublishToGitHubPages.yml
+++ b/.github/workflows/PublishToGitHubPages.yml
@@ -1,0 +1,62 @@
+name: Publish to GitHub Pages
+
+on:
+  workflow_call:
+    inputs:
+      doc:
+        description: 'Name of the documentation artifact.'
+        required: true
+        type: string
+      coverage:
+        description: 'Name of the coverage artifact.'
+        required: false
+        default: ''
+        type: string
+      typing:
+        description: 'Name of the typing artifact.'
+        required: false
+        default: ''
+        type: string
+
+jobs:
+
+  PublishToGitHubPages:
+    name: 📚 Publish to GH-Pages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: 📥 Download artifacts '${{ inputs.doc }}' from 'BuildTheDocs' job
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ inputs.doc }}
+          path: public
+
+      - name: 📥 Download artifacts '${{ inputs.coverage }}' from 'Coverage' job
+        if: ${{ inputs.coverage != '' }}
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ inputs.coverage }}
+          path: public/coverage
+
+      - name: 📥 Download artifacts '${{ inputs.typing }}' from 'StaticTypeCheck' job
+        if: ${{ inputs.typing != '' }}
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ inputs.typing }}
+          path: public/typing
+
+      - name: '📓 Publish site to GitHub Pages'
+        if: github.event_name != 'pull_request'
+        run: |
+          cd public
+          touch .nojekyll
+          git init
+          cp ../.git/config ./.git/config
+          git add .
+          git config --local user.email "BuildTheDocs@GitHubActions"
+          git config --local user.name "GitHub Actions"
+          git commit -a -m "update ${{ github.sha }}"
+          git push -u origin +HEAD:gh-pages

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  workflow_call:
+
+jobs:
+
+  Release:
+    name: 📝 Create 'Release Page' on GitHub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🔁 Extract Git tag from GITHUB_REF
+        id: getVariables
+        run: |
+          GIT_TAG=${GITHUB_REF#refs/*/}
+          RELEASE_VERSION=${GIT_TAG#v}
+          RELEASE_DATETIME="$(date --utc '+%d.%m.%Y - %H:%M:%S')"
+          # write to step outputs
+          echo ::set-output name=gitTag::${GIT_TAG}
+          echo ::set-output name=version::${RELEASE_VERSION}
+          echo ::set-output name=datetime::${RELEASE_DATETIME}
+
+      - name: 📑 Create Release Page
+        id: createReleasePage
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tag_name: ${{ steps.getVariables.outputs.gitTag }}
+#          release_name: ${{ steps.getVariables.outputs.gitTag }}
+          body: |
+            **Automated Release created on: ${{ steps.getVariables.outputs.datetime }}**
+
+            # New Features
+            * tbd
+
+            # Changes
+            * tbd
+
+            # Bug Fixes
+            * tbd
+          draft: false
+          prerelease: false

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -23,7 +23,7 @@ on:
         required: true
         type: string
       artifact:
-        description: 'Name of the coverage artifact.'
+        description: 'Name of the typing artifact.'
         required: true
         type: string
 

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -7,7 +7,7 @@ on:
         description: 'Name of the Python package.'
         required: true
         type: string
-      pyver:
+      python_version:
         description: 'Python version.'
         required: false
         default: '3.10'
@@ -20,17 +20,17 @@ on:
 jobs:
 
   StaticTypeCheck:
-    name: 👀 Check Static Typing using Python ${{ inputs.pyver }}
+    name: 👀 Check Static Typing using Python ${{ inputs.python_version }}
     runs-on: ubuntu-latest
 
     steps:
       - name: ⏬ Checkout repository
         uses: actions/checkout@v2
 
-      - name: 🐍 Setup Python ${{ inputs.pyver }}
+      - name: 🐍 Setup Python ${{ inputs.python_version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ inputs.pyver }}
+          python-version: ${{ inputs.python_version }}
 
       - name: 🗂 Install dependencies
         run: |

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: '3.10'
         type: string
+      requirements:
+        description: 'Python dependencies to be installed through pip.'
+        required: false
+        default: '-r tests/requirements.txt'
+        type: string
       artifact:
         description: 'Name of the coverage artifact.'
         required: true
@@ -34,14 +39,12 @@ jobs:
 
       - name: 🗂 Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r tests/requirements.txt
+          python -m pip install -U pip
+          python -m pip install ${{ inputs.requirements }}
 
       - name: Check Static Typing
         continue-on-error: true
-        run: |
-          pwd
-          mypy --html-report htmlmypy -m ${{ inputs.package }}
+        run: mypy --html-report htmlmypy -m ${{ inputs.package }}
 
       - name: 📤 Upload 'Static Typing Report' artifact
         continue-on-error: true

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -3,10 +3,6 @@ name: Static Type Check
 on:
   workflow_call:
     inputs:
-      package:
-        description: 'Name of the Python package.'
-        required: true
-        type: string
       python_version:
         description: 'Python version.'
         required: false
@@ -16,6 +12,15 @@ on:
         description: 'Python dependencies to be installed through pip.'
         required: false
         default: '-r tests/requirements.txt'
+        type: string
+      html_report:
+        description: 'Directory for --html-report.'
+        required: false
+        default: 'htmlmypy'
+        type: string
+      mypy_args:
+        description: 'Arguments to mypy, except the HTML report (see option html_report).'
+        required: true
         type: string
       artifact:
         description: 'Name of the coverage artifact.'
@@ -44,13 +49,16 @@ jobs:
 
       - name: Check Static Typing
         continue-on-error: true
-        run: mypy --html-report htmlmypy -m ${{ inputs.package }}
+        run: |
+          [ 'x${{ inputs.html_report }}' != 'x' ] && MYPY_HTML='--html-report=${{ inputs.html_report }}' || unset MYPY_HTML
+          mypy $MYPY_HTML ${{ inputs.mypy_args }}
 
       - name: 📤 Upload 'Static Typing Report' artifact
+        if: ${{ inputs.html_report != '' }}
         continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
           name: ${{ inputs.artifact }}
-          path: htmlmypy
+          path: ${{ inputs.html_report }}
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -1,0 +1,53 @@
+name: Static Type Check
+
+on:
+  workflow_call:
+    inputs:
+      package:
+        description: 'Name of the Python package.'
+        required: true
+        type: string
+      pyver:
+        description: 'Python version.'
+        required: false
+        default: '3.10'
+        type: string
+      artifact:
+        description: 'Name of the coverage artifact.'
+        required: true
+        type: string
+
+jobs:
+
+  StaticTypeCheck:
+    name: 👀 Check Static Typing using Python ${{ inputs.pyver }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⏬ Checkout repository
+        uses: actions/checkout@v2
+
+      - name: 🐍 Setup Python ${{ inputs.pyver }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ inputs.pyver }}
+
+      - name: 🗂 Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/requirements.txt
+
+      - name: Check Static Typing
+        continue-on-error: true
+        run: |
+          pwd
+          mypy --html-report htmlmypy -m ${{ inputs.package }}
+
+      - name: 📤 Upload 'Static Typing Report' artifact
+        continue-on-error: true
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ inputs.artifact }}
+          path: htmlmypy
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -13,13 +13,13 @@ on:
         required: false
         default: '-r tests/requirements.txt'
         type: string
-      html_report:
-        description: 'Directory for --html-report.'
+      report:
+        description: 'Directory to upload as an artifact.'
         required: false
         default: 'htmlmypy'
         type: string
-      mypy_args:
-        description: 'Arguments to mypy, except the HTML report (see option html_report).'
+      commands:
+        description: 'Commands to run the static type checks.'
         required: true
         type: string
       artifact:
@@ -49,16 +49,14 @@ jobs:
 
       - name: Check Static Typing
         continue-on-error: true
-        run: |
-          [ 'x${{ inputs.html_report }}' != 'x' ] && MYPY_HTML='--html-report=${{ inputs.html_report }}' || unset MYPY_HTML
-          mypy $MYPY_HTML ${{ inputs.mypy_args }}
+        run: ${{ inputs.commands }}
 
       - name: 📤 Upload 'Static Typing Report' artifact
-        if: ${{ inputs.html_report != '' }}
+        if: ${{ inputs.artifact != '' }}
         continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
           name: ${{ inputs.artifact }}
-          path: ${{ inputs.html_report }}
+          path: ${{ inputs.report }}
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -3,6 +3,11 @@ name: Unit Testing
 on:
   workflow_call:
     inputs:
+      python_versions:
+        description: 'Space separated list of Python versions to run tests with.'
+        required: false
+        default: '3.6 3.7 3.8 3.9 3.10'
+        type: string
       requirements:
         description: 'Python dependencies to be installed through pip.'
         required: false
@@ -16,19 +21,40 @@ on:
 
 jobs:
 
+
+  Versions:
+    runs-on: ubuntu-latest
+    outputs:
+      jobs: ${{ steps.versions.outputs.jobs }}
+    steps:
+
+      - id: versions
+        shell: python
+        run: |
+          icons = {
+             '3.6': '🔴', # until 23.12.2021
+             '3.7': '🟠', # until 27.06.2023
+             '3.8': '🟡', # until Oct. 2024
+             '3.9': '🟢', # until Oct. 2025
+            '3.10': '🟢', # until Oct. 2026
+          }
+          jobs = [
+              {'python': version, 'icon': icons[version]}
+              for version in '${{ inputs.python_versions }}'.split(' ')
+          ]
+          print(f'::set-output name=jobs::{jobs!s}')
+
+
   UnitTesting:
     name: ${{ matrix.icon }} Unit Tests using Python ${{ matrix.python }}
     runs-on: ubuntu-latest
+    needs:
+      - Versions
 
     strategy:
       fail-fast: false
       matrix:
-        include:
-#          - {python: "3.6",  icon: 🔴} # until 23.12.2021
-          - {python: "3.7",  icon: 🟠} # until 27.06.2023
-          - {python: "3.8",  icon: 🟡} # until Oct. 2024
-          - {python: "3.9",  icon: 🟢} # until Oct. 2025
-          - {python: "3.10", icon: 🟢} # until Oct. 2026
+        include: ${{ fromJson(needs.Versions.outputs.jobs) }}
 
     steps:
       - name: ⏬ Checkout repository

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -3,6 +3,11 @@ name: Unit Testing
 on:
   workflow_call:
     inputs:
+      requirements:
+        description: 'Python dependencies to be installed through pip.'
+        required: false
+        default: '-r tests/requirements.txt'
+        type: string
       TestReport:
         description: "Generate unit test report with junitxml and upload results as an artifact."
         required: false
@@ -36,8 +41,8 @@ jobs:
 
       - name: 🔧 Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r tests/requirements.txt
+          python -m pip install -U pip
+          python -m pip install ${{ inputs.requirements }}
 
       - name: ☑ Run unit tests
         run: |

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -1,0 +1,54 @@
+name: Unit Testing
+
+on:
+  workflow_call:
+    inputs:
+      TestReport:
+        description: "Generate unit test report with junitxml and upload results as an artifact."
+        required: false
+        default: false
+        type: string
+
+jobs:
+
+  UnitTesting:
+    name: ${{ matrix.icon }} Unit Tests using Python ${{ matrix.python }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+#          - {python: "3.6",  icon: 🔴} # until 23.12.2021
+          - {python: "3.7",  icon: 🟠} # until 27.06.2023
+          - {python: "3.8",  icon: 🟡} # until Oct. 2024
+          - {python: "3.9",  icon: 🟢} # until Oct. 2025
+          - {python: "3.10", icon: 🟢} # until Oct. 2026
+
+    steps:
+      - name: ⏬ Checkout repository
+        uses: actions/checkout@v2
+
+      - name: 🐍 Setup Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: 🔧 Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/requirements.txt
+
+      - name: ☑ Run unit tests
+        run: |
+          [ '${{ inputs.TestReport }}' = 'true' ] && PYTEST_ARGS='--junitxml=TestReport.xml' || unset PYTEST_ARGS
+          python -m pytest -rA tests/unit $PYTEST_ARGS --color=yes
+
+      - name: 📤 Upload 'TestReport.xml' artifact
+        if: inputs.TestReport == 'true'
+        uses: actions/upload-artifact@v2
+        with:
+          name: TestReport-${{ matrix.python }}
+          path: TestReport.xml
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -3,10 +3,9 @@ name: Unit Testing
 on:
   workflow_call:
     inputs:
-      python_versions:
+      jobs:
         description: 'Space separated list of Python versions to run tests with.'
-        required: false
-        default: '3.6 3.7 3.8 3.9 3.10'
+        required: true
         type: string
       requirements:
         description: 'Python dependencies to be installed through pip.'
@@ -21,40 +20,14 @@ on:
 
 jobs:
 
-
-  Versions:
-    runs-on: ubuntu-latest
-    outputs:
-      jobs: ${{ steps.versions.outputs.jobs }}
-    steps:
-
-      - id: versions
-        shell: python
-        run: |
-          icons = {
-             '3.6': '🔴', # until 23.12.2021
-             '3.7': '🟠', # until 27.06.2023
-             '3.8': '🟡', # until Oct. 2024
-             '3.9': '🟢', # until Oct. 2025
-            '3.10': '🟢', # until Oct. 2026
-          }
-          jobs = [
-              {'python': version, 'icon': icons[version]}
-              for version in '${{ inputs.python_versions }}'.split(' ')
-          ]
-          print(f'::set-output name=jobs::{jobs!s}')
-
-
   UnitTesting:
     name: ${{ matrix.icon }} Unit Tests using Python ${{ matrix.python }}
     runs-on: ubuntu-latest
-    needs:
-      - Versions
 
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.Versions.outputs.jobs) }}
+        include: ${{ fromJson(inputs.jobs) }}
 
     steps:
       - name: ⏬ Checkout repository

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -12,10 +12,10 @@ on:
         required: false
         default: '-r tests/requirements.txt'
         type: string
-      TestReport:
+      artifact:
         description: "Generate unit test report with junitxml and upload results as an artifact."
         required: false
-        default: false
+        default: ''
         type: string
 
 jobs:
@@ -45,14 +45,14 @@ jobs:
 
       - name: ☑ Run unit tests
         run: |
-          [ '${{ inputs.TestReport }}' = 'true' ] && PYTEST_ARGS='--junitxml=TestReport.xml' || unset PYTEST_ARGS
+          [ 'x${{ inputs.artifact }}' != 'x' ] && PYTEST_ARGS='--junitxml=TestReport.xml' || unset PYTEST_ARGS
           python -m pytest -rA tests/unit $PYTEST_ARGS --color=yes
 
       - name: 📤 Upload 'TestReport.xml' artifact
         if: inputs.TestReport == 'true'
         uses: actions/upload-artifact@v2
         with:
-          name: TestReport-${{ matrix.python }}
+          name: ${{ inputs.artifact }}-${{ matrix.python }}
           path: TestReport.xml
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/VerifyDocs.yml
+++ b/.github/workflows/VerifyDocs.yml
@@ -1,0 +1,56 @@
+name: Verify examples
+
+on:
+  workflow_call:
+    inputs:
+      pyver:
+        description: 'Python version.'
+        required: false
+        default: '3.10'
+        type: string
+
+jobs:
+
+  VerifyDocs:
+    name: 👍 Verify example snippets using Python ${{ inputs.pyver }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⏬ Checkout repository
+        uses: actions/checkout@v2
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ inputs.pyver }}
+
+      - name: 🐍 Install dependencies
+        run: |
+          pip3 install .
+
+      - name: ✂ Extract code snippet from README
+        shell: python
+        run: |
+          from pathlib import Path
+          import re
+
+          ROOT = Path('.')
+
+          with (ROOT / 'README.md').open('r') as rptr:
+              content = rptr.read()
+
+          m = re.search(r"```py(thon)?(?P<code>.*?)```", content, re.MULTILINE|re.DOTALL)
+
+          if m is None:
+              raise Exception("Regular expression did not find the example in the README!")
+
+          with (ROOT / 'tests/docs/example.py').open('w') as wptr:
+              wptr.write(m["code"])
+
+      - name: Print example.py
+        run: cat tests/docs/example.py
+
+      - name: ☑ Run example snippet
+        working-directory: tests/docs
+        run: |
+          python3 example.py

--- a/.github/workflows/VerifyDocs.yml
+++ b/.github/workflows/VerifyDocs.yml
@@ -3,7 +3,7 @@ name: Verify examples
 on:
   workflow_call:
     inputs:
-      pyver:
+      python_version:
         description: 'Python version.'
         required: false
         default: '3.10'
@@ -12,7 +12,7 @@ on:
 jobs:
 
   VerifyDocs:
-    name: 👍 Verify example snippets using Python ${{ inputs.pyver }}
+    name: 👍 Verify example snippets using Python ${{ inputs.python_version }}
     runs-on: ubuntu-latest
 
     steps:
@@ -22,7 +22,7 @@ jobs:
       - name: 🐍 Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ inputs.pyver }}
+          python-version: ${{ inputs.python_version }}
 
       - name: 🐍 Install dependencies
         run: |

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -21,7 +21,7 @@ jobs:
       jobs: ${{ needs.Params.outputs.python_jobs }}
       # Optional
       requirements: '-r tests/requirements.txt'
-      TestReport: true
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}
 
   Coverage:
     uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@dev

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -1,0 +1,115 @@
+name: Unit Testing, Coverage Collection, Package, Release, Documentation and Publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  # This job is a workaround for global variables
+  # See https://github.com/actions/runner/issues/480
+  Params:
+    uses: pyTooling/Actions/.github/workflows/Params.yml@dev
+    with:
+      name: ToolName
+
+  UnitTesting:
+    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev
+    with:
+      TestReport: true
+
+  Coverage:
+    uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@dev
+    needs:
+      - Params
+    with:
+      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
+    secrets:
+      codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+
+  StaticTypeCheck:
+    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@dev
+    needs:
+      - Params
+    with:
+      package: ${{ fromJson(needs.Params.outputs.params).package }}
+      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
+
+  Release:
+    uses: pyTooling/Actions/.github/workflows/Release.yml@dev
+    if: startsWith(github.ref, 'refs/tags')
+    needs:
+      - UnitTesting
+      - Coverage
+      - StaticTypeCheck
+
+  Package:
+    uses: pyTooling/Actions/.github/workflows/Package.yml@dev
+    if: startsWith(github.ref, 'refs/tags')
+    needs:
+      - Params
+      - Coverage
+    with:
+      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
+
+  PublishOnPyPI:
+    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@dev
+    if: startsWith(github.ref, 'refs/tags')
+    needs:
+      - Params
+      - Release
+      - Package
+    with:
+      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+
+  VerifyDocs:
+    uses: pyTooling/Actions/.github/workflows/VerifyDocs.yml@dev
+    needs:
+      - Params
+    with:
+      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+
+  BuildTheDocs:
+    uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@dev
+    needs:
+      - Params
+      - VerifyDocs
+    with:
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
+
+  PublishToGitHubPages:
+    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@dev
+    needs:
+      - Params
+      - BuildTheDocs
+      - Coverage
+      - StaticTypeCheck
+    with:
+      doc: ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
+      coverage: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
+      typing: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
+
+
+  ArtifactCleanUp:
+    name: 🗑️ Artifact Cleanup
+    runs-on: ubuntu-latest
+    needs:
+      - Params
+      - Coverage
+      - StaticTypeCheck
+      - BuildTheDocs
+      - PublishToGitHubPages
+
+    steps:
+      - name: 🗑️ Delete all Artifacts
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: |
+            ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
+            ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
+            ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -22,7 +22,7 @@ jobs:
     needs:
       - Params
     with:
-      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
     secrets:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
       - Params
     with:
       package: ${{ fromJson(needs.Params.outputs.params).package }}
-      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
 
   Release:
@@ -51,7 +51,7 @@ jobs:
       - Params
       - Coverage
     with:
-      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
 
   PublishOnPyPI:
@@ -62,7 +62,7 @@ jobs:
       - Release
       - Package
     with:
-      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
     needs:
       - Params
     with:
-      pyver: ${{ fromJson(needs.Params.outputs.params).pyver }}
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
 
   BuildTheDocs:
     uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@dev

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -111,31 +111,18 @@ jobs:
       coverage: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
       typing: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
 
-
   ArtifactCleanUp:
-    name: 🗑️ Artifact Cleanup
-    runs-on: ubuntu-latest
+    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@main
     needs:
       - Params
       - Coverage
       - StaticTypeCheck
       - BuildTheDocs
       - PublishToGitHubPages
-
-    steps:
-
-      - name: 🗑️ Delete package Artifacts
-        if: ${{ ! startsWith(github.ref, 'refs/tags') }}
-        uses: geekyeggo/delete-artifact@v1
-        with:
-          name: |
-            ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
-
-      - name: 🗑️ Delete remaining Artifacts
-        uses: geekyeggo/delete-artifact@v1
-        with:
-          name: |
-            ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-*
-            ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
-            ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
-            ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
+    with:
+      package: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
+      remaining: |
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-*
+        ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
+        ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
+        ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -123,10 +123,19 @@ jobs:
       - PublishToGitHubPages
 
     steps:
-      - name: 🗑️ Delete all Artifacts
+
+      - name: 🗑️ Delete package Artifacts
+        if: ${{ ! startsWith(github.ref, 'refs/tags') }}
         uses: geekyeggo/delete-artifact@v1
         with:
           name: |
+            ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
+
+      - name: 🗑️ Delete remaining Artifacts
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: |
+            ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-*
             ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
             ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
             ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -40,12 +40,12 @@ jobs:
     needs:
       - Params
     with:
-      mypy_args: -m ${{ fromJson(needs.Params.outputs.params).name }}
+      commands: mypy --html-report htmlmypy -p ToolName
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
       # Optional
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       requirements: '-r tests/requirements.txt'
-      html_report: 'htmlmypy'
+      report: 'htmlmypy'
 
   Release:
     uses: pyTooling/Actions/.github/workflows/Release.yml@dev

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -11,10 +11,16 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/Params.yml@dev
     with:
       name: ToolName
+      # Optional
+      python_version: '3.10'
+      python_version_list: '3.8 3.9 3.10'
 
   UnitTesting:
     uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev
     with:
+      jobs: ${{ needs.Params.outputs.python_jobs }}
+      # Optional
+      requirements: '-r tests/requirements.txt'
       TestReport: true
 
   Coverage:
@@ -22,8 +28,10 @@ jobs:
     needs:
       - Params
     with:
-      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
+      # Optional
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
+      requirements: '-r tests/requirements.txt'
     secrets:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
@@ -32,9 +40,12 @@ jobs:
     needs:
       - Params
     with:
-      package: ${{ fromJson(needs.Params.outputs.params).package }}
-      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
+      mypy_args: -m ${{ fromJson(needs.Params.outputs.params).package }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
+      # Optional
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
+      requirements: '-r tests/requirements.txt'
+      html_report: 'htmlmypy'
 
   Release:
     uses: pyTooling/Actions/.github/workflows/Release.yml@dev
@@ -51,8 +62,10 @@ jobs:
       - Params
       - Coverage
     with:
-      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
+      # Optional
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
+      requirements: 'wheel'
 
   PublishOnPyPI:
     uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@dev
@@ -62,8 +75,10 @@ jobs:
       - Release
       - Package
     with:
-      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
+      # Optional
+      python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
+      requirements: 'wheel twine'
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
@@ -72,6 +87,7 @@ jobs:
     needs:
       - Params
     with:
+      # Optional
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
 
   BuildTheDocs:
@@ -91,6 +107,7 @@ jobs:
       - StaticTypeCheck
     with:
       doc: ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
+      # Optional
       coverage: ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
       typing: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
 

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -8,7 +8,7 @@ jobs:
   # This job is a workaround for global variables
   # See https://github.com/actions/runner/issues/480
   Params:
-    uses: pyTooling/Actions/.github/workflows/Params.yml@dev
+    uses: pyTooling/Actions/.github/workflows/Params.yml@main
     with:
       name: ToolName
       # Optional
@@ -16,7 +16,7 @@ jobs:
       python_version_list: '3.8 3.9 3.10'
 
   UnitTesting:
-    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev
+    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@main
     with:
       jobs: ${{ needs.Params.outputs.python_jobs }}
       # Optional
@@ -24,7 +24,7 @@ jobs:
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}
 
   Coverage:
-    uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@dev
+    uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@main
     needs:
       - Params
     with:
@@ -36,7 +36,7 @@ jobs:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   StaticTypeCheck:
-    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@dev
+    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@main
     needs:
       - Params
     with:
@@ -48,7 +48,7 @@ jobs:
       report: 'htmlmypy'
 
   Release:
-    uses: pyTooling/Actions/.github/workflows/Release.yml@dev
+    uses: pyTooling/Actions/.github/workflows/Release.yml@main
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - UnitTesting
@@ -56,7 +56,7 @@ jobs:
       - StaticTypeCheck
 
   Package:
-    uses: pyTooling/Actions/.github/workflows/Package.yml@dev
+    uses: pyTooling/Actions/.github/workflows/Package.yml@main
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - Params
@@ -68,7 +68,7 @@ jobs:
       requirements: 'wheel'
 
   PublishOnPyPI:
-    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@dev
+    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@main
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - Params
@@ -83,7 +83,7 @@ jobs:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
   VerifyDocs:
-    uses: pyTooling/Actions/.github/workflows/VerifyDocs.yml@dev
+    uses: pyTooling/Actions/.github/workflows/VerifyDocs.yml@main
     needs:
       - Params
     with:
@@ -91,7 +91,7 @@ jobs:
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
 
   BuildTheDocs:
-    uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@dev
+    uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@main
     needs:
       - Params
       - VerifyDocs
@@ -99,7 +99,7 @@ jobs:
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}
 
   PublishToGitHubPages:
-    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@dev
+    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@main
     needs:
       - Params
       - BuildTheDocs

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -40,7 +40,7 @@ jobs:
     needs:
       - Params
     with:
-      mypy_args: -m ${{ fromJson(needs.Params.outputs.params).package }}
+      mypy_args: -m ${{ fromJson(needs.Params.outputs.params).name }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
       # Optional
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
@@ -62,7 +62,7 @@ jobs:
       - Params
       - Coverage
     with:
-      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
       # Optional
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       requirements: 'wheel'
@@ -75,7 +75,7 @@ jobs:
       - Release
       - Package
     with:
-      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.wheel }}
+      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
       # Optional
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       requirements: 'wheel twine'


### PR DESCRIPTION
This PR adds 11 reusable workflows, based on the jobs used in repos from this organisation, [EDA²](https://github.com/edaa-org), [VHDL](https://github.com/vhdl), and others.

The expected order is:

- Params.yml
- UnitTesting.yml
- CoverageCollection.yml
- StaticTypeCheck.yml
- Release.yml
- Package.yml
- PublishOnPyPI.yml
- VerifyDocs.yml 
- BuildTheDocs.yml
- PublishToGitHubPages.yml
- ArtifactCleanUp

Moreover, an example workflow named `ExamplePipeline.yml` is provided, for tool developers to copy it into their repos. The only required modification should be setting the `name` input of job `Params`.

IMPORTANT: reusable workflows must be used through an absolute name and specifying a version (see actions/runner#1493). Therefore, this PR will be kept as a draft, because `s/@dev/@main/` is required in `ExamplePipeline.yml` before merging.