### PR TITLE
add Action 'with-post-step'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Actions
 
 Reusable steps and workflows for GitHub Actions, focused on Python packages.
+
+## Script with post step
+
+JavaScript Actions support defining `pre`, `pre-if`, `post` and `post-if` steps, which allow executing steps at the
+beginning or the end of a job, regardless of intermediate steps failing.
+Unfortunately, those are not available for any other Action type.
+
+Action [with-post-step](with-post-step) is a generic JS Action to execute a main command and to set a command as a post
+step.
+It allows using the `post` feature with scripts written in bash, python or any other interpreted language available on
+the environment.
+See: [actions/runner#1478](https://github.com/actions/runner/issues/1478).

--- a/with-post-step/action.yml
+++ b/with-post-step/action.yml
@@ -1,0 +1,17 @@
+name: With post step
+description: 'Generic JS Action to execute a main command and set a command as a post step.'
+inputs:
+  main:
+    description: 'Main command/script.'
+    required: true
+  post:
+    description: 'Post command/script.'
+    required: true
+  key:
+    description: 'Name of the state variable used to detect the post step.'
+    required: false
+    default: POST
+runs:
+  using: 'node12'
+  main: 'main.js'
+  post: 'main.js'

--- a/with-post-step/main.js
+++ b/with-post-step/main.js
@@ -21,12 +21,12 @@
 // * https://github.com/docker/login-action/issues/72
 // * https://github.com/actions/runner/issues/1478
 
-const { exec } = require('child_process');
+const { exec } = require("child_process");
 
 function run(cmd) {
   exec(cmd, (error, stdout, stderr) => {
-    if ( stdout.length != 0 ) { console.log(`${stdout}`); }
-    if ( stderr.length != 0 ) { console.error(`${stderr}`); }
+    if ( stdout.length !== 0 ) { console.log(`${stdout}`); }
+    if ( stderr.length !== 0 ) { console.error(`${stderr}`); }
     if (error) {
       process.exitCode = error.code;
       console.error(`${error}`);
@@ -36,7 +36,7 @@ function run(cmd) {
 
 const key = process.env.INPUT_KEY.toUpperCase();
 
-if ( process.env[`STATE_${key}`] != undefined ) { // Are we in the 'post' step?
+if ( process.env[`STATE_${key}`] !== undefined ) { // Are we in the 'post' step?
   run(process.env.INPUT_POST);
 } else { // Otherwise, this is the main step
   console.log(`::save-state name=${key}::true`);

--- a/with-post-step/main.js
+++ b/with-post-step/main.js
@@ -1,0 +1,44 @@
+// Authors:
+//   Unai Martinez-Corral
+//
+// Copyright 2021 Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Context:
+// * https://github.com/docker/login-action/issues/72
+// * https://github.com/actions/runner/issues/1478
+
+const { exec } = require('child_process');
+
+function run(cmd) {
+  exec(cmd, (error, stdout, stderr) => {
+    if ( stdout.length != 0 ) { console.log(`${stdout}`); }
+    if ( stderr.length != 0 ) { console.error(`${stderr}`); }
+    if (error) {
+      process.exitCode = error.code;
+      console.error(`${error}`);
+    }
+  });
+}
+
+const key = process.env.INPUT_KEY.toUpperCase();
+
+if ( process.env[`STATE_${key}`] != undefined ) { // Are we in the 'post' step?
+  run(process.env.INPUT_POST);
+} else { // Otherwise, this is the main step
+  console.log(`::save-state name=${key}::true`);
+  run(process.env.INPUT_MAIN);
+}


### PR DESCRIPTION
This PR adds a generic JS to allow executing some command and, at the same time, defining another command to be executed as a `post` step (at the end of the job). This wrapper allows using bash, python, or any other interpreted language, instead of just plain JavaScript.