### PR TITLE
Add a job template to publish unit test results

### DIFF
--- a/.github/workflows/PublishTestResults.yml
+++ b/.github/workflows/PublishTestResults.yml
@@ -1,0 +1,54 @@
+# ==============================================================================
+# Authors:
+#   Patrick Lehmann
+#   Unai Martinez-Corral
+#
+# ==============================================================================
+# Copyright 2020-2021 The pyTooling Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ==============================================================================
+name: Publish Unit Test Results
+
+on:
+  workflow_call:
+
+jobs:
+  PublishTestResults:
+    name: 📊 Publish Test Results to Issue Comment
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+      - name: ⏬ Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+
+# TODO: @umarcor do we want to make it optional or just kick it out?
+#      - name: 💬 Comment Unit Test Results in Pull Request
+#        uses: EnricoMi/publish-unit-test-result-action@v1
+#        with:
+#          files: artifacts/**/*.xml
+
+      - name: 📊 Publish Unit Test Results
+        uses: dorny/test-reporter@v1
+        with:
+          name: Unit Test Results
+          path: artifacts/**/*.xml
+          reporter: java-junit

--- a/.github/workflows/PublishTestResults.yml
+++ b/.github/workflows/PublishTestResults.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   PublishTestResults:
-    name: 📊 Publish Test Results to Issue Comment
+    name: 📊 Publish Test Results
     runs-on: ubuntu-latest
     if: always()
 

--- a/.github/workflows/PublishTestResults.yml
+++ b/.github/workflows/PublishTestResults.yml
@@ -24,6 +24,12 @@ name: Publish Unit Test Results
 
 on:
   workflow_call:
+    inputs:
+      report_files:
+        description: 'Pattern of report files to upload. Can be a comma separated list.'
+        required: false
+        default: 'artifacts/**/*.xml'
+        type: string
 
 jobs:
   PublishTestResults:
@@ -44,5 +50,5 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           name: Unit Test Results
-          path: artifacts/**/*.xml
+          path: ${{ inputs.report_files }}
           reporter: java-junit

--- a/.github/workflows/PublishTestResults.yml
+++ b/.github/workflows/PublishTestResults.yml
@@ -40,12 +40,6 @@ jobs:
         with:
           path: artifacts
 
-# TODO: @umarcor do we want to make it optional or just kick it out?
-#      - name: 💬 Comment Unit Test Results in Pull Request
-#        uses: EnricoMi/publish-unit-test-result-action@v1
-#        with:
-#          files: artifacts/**/*.xml
-
       - name: 📊 Publish Unit Test Results
         uses: dorny/test-reporter@v1
         with:

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -49,6 +49,11 @@ jobs:
       requirements: '-r tests/requirements.txt'
       report: 'htmlmypy'
 
+  PublishTestResults:
+    uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@main
+    needs:
+      - UnitTesting
+
   Package:
     uses: pyTooling/Actions/.github/workflows/Package.yml@main
     needs:

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -53,6 +53,9 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@main
     needs:
       - UnitTesting
+    with:
+      # Optional
+      report_files: artifacts/**/*.xml
 
   Package:
     uses: pyTooling/Actions/.github/workflows/Package.yml@main

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ As shown in the screenshot above, the expected order is:
   - [Release](.github/workflows/Release.yml): publish GitHub Release.
   - [Package](.github/workflows/Package.yml): generate source and wheel packages, and upload them as an artifact.
   - [PublishOnPyPI](.github/workflows/PublishOnPyPI.yml): publish source and wheel packages to PyPI.
+  - [PublishTestResults](.github/workflows/PublishTestResults.yml): publish unit test results through GH action `dorny/test-reporter`.
 - Documentation:
   - [BuildTheDocs](.github/workflows/BuildTheDocs.yml): build Sphinx documentation with BuildTheDocs, and upload HTML as
     an artifact.


### PR DESCRIPTION
Add a new job template to publish unit test results in junit XML format via GH Action `dorny/test-reporter` to GitHubs API displaying an auto generated markdown file in list of jobs executed in a pipeline.

-------------
This PR fixes #8.  
Depends on #11 