### PR TITLE
Added 'allow_failure' option for StaticTypeCheck job.

### DIFF
--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -36,7 +36,7 @@ on:
         default: '3.6 3.7 3.8 3.9 3.10'
         type: string
       name:
-        description: 'Name of the tool.'
+        description: 'Name of the tool/package.'
         required: true
         type: string
     outputs:

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -44,6 +44,11 @@ on:
         description: 'Commands to run the static type checks.'
         required: true
         type: string
+      allow_failure:
+        description: 'Allow a type checking to be failing without failing the overall workflow.'
+        required: false
+        default: false
+        type: boolean
       artifact:
         description: 'Name of the typing artifact.'
         required: true
@@ -70,12 +75,12 @@ jobs:
           python -m pip install ${{ inputs.requirements }}
 
       - name: Check Static Typing
-        continue-on-error: true
+        continue-on-error: ${{ inputs.allow_failure }}
         run: ${{ inputs.commands }}
 
       - name: 📤 Upload 'Static Typing Report' artifact
         if: ${{ inputs.artifact != '' }}
-        continue-on-error: true
+        continue-on-error: ${{ inputs.allow_failure }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ inputs.artifact }}


### PR DESCRIPTION
# New Features
* Adds an `allow_failure` option to the StaticTypeCheck job.

# Changes
* Static type checking whill fail the pipeline, if `allow_failure` isn't set to `true` in case of errors reported by mypy.

# Bug Fixes
*None*
