### PR TITLE
v0.2.0

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -31,9 +31,9 @@ on:
         default: '3.10'
         type: string
       requirements:
-        description: 'Python dependencies to be installed through pip.'
+        description: 'Python dependencies to be installed through pip; if empty, use pyproject.toml through build.'
         required: false
-        default: 'wheel'
+        default: ''
         type: string
       artifact:
         description: 'Name of the package artifact.'
@@ -55,16 +55,37 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
-      - name: 🔧 Install dependencies for packaging and release
-        run: |
-          python -m pip install -U pip
-          python -m pip install ${{ inputs.requirements }}
+      - name: 🐍 Update pip
+        run: python -m pip install -U pip
 
-      - name: 🔨 Build Python package (source distribution)
+      # build
+
+      - name: 🔧 [build] Install dependencies for packaging and release
+        if: inputs.requirements == ''
+        run: python -m pip install build
+
+      - name: 🔨 [build] Build Python package (source distribution)
+        if: inputs.requirements == ''
+        run: python -m build --sdist
+
+      - name: 🔨 [build] Build Python package (binary distribution - wheel)
+        if: inputs.requirements == ''
+        run: python -m build --wheel
+
+      # setuptools
+
+      - name: 🔧 [setuptools] Install dependencies for packaging and release
+        if: inputs.requirements != ''
+        run: python -m pip install ${{ inputs.requirements }}
+
+      - name: 🔨 [setuptools] Build Python package (source distribution)
+        if: inputs.requirements != ''
         run: python setup.py sdist
 
-      - name: 🔨 Build Python package (binary distribution - wheel)
+      - name: 🔨 [setuptools] Build Python package (binary distribution - wheel)
+        if: inputs.requirements != ''
         run: python setup.py bdist_wheel
+
 
       - name: 📤 Upload wheel artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -36,7 +36,7 @@ on:
         default: '3.6 3.7 3.8 3.9 3.10'
         type: string
       name:
-        description: 'Name of the tool.'
+        description: 'Name of the tool/package.'
         required: true
         type: string
     outputs:

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -44,6 +44,11 @@ on:
         description: 'Commands to run the static type checks.'
         required: true
         type: string
+      allow_failure:
+        description: 'Allow a type checking to be failing without failing the overall workflow.'
+        required: false
+        default: false
+        type: boolean
       artifact:
         description: 'Name of the typing artifact.'
         required: true
@@ -70,12 +75,12 @@ jobs:
           python -m pip install ${{ inputs.requirements }}
 
       - name: Check Static Typing
-        continue-on-error: true
+        continue-on-error: ${{ inputs.allow_failure }}
         run: ${{ inputs.commands }}
 
       - name: 📤 Upload 'Static Typing Report' artifact
         if: ${{ inputs.artifact != '' }}
-        continue-on-error: true
+        continue-on-error: ${{ inputs.allow_failure }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ inputs.artifact }}

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -70,6 +70,7 @@ jobs:
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       requirements: '-r tests/requirements.txt'
       report: 'htmlmypy'
+      allow_failure: true
 
   PublishTestResults:
     uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@main


### PR DESCRIPTION
# New Features
* Adds an `allow_failure` option to the [StaticTypeCheck](https://github.com/pyTooling/Actions/blob/main/.github/workflows/StaticTypeCheck.yml) job.

# Changes
* Static type checking will fail the pipeline, if `allow_failure` isn't set to `true` in case of errors reported by mypy.

# Bug Fixes
* tbd

------------
/cc @umarcor 