### PR TITLE
Package: support either 'build' or 'setuptools'

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -33,7 +33,7 @@ on:
       requirements:
         description: 'Python dependencies to be installed through pip.'
         required: false
-        default: 'wheel'
+        default: ''
         type: string
       artifact:
         description: 'Name of the package artifact.'
@@ -55,16 +55,37 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
-      - name: 🔧 Install dependencies for packaging and release
-        run: |
-          python -m pip install -U pip
-          python -m pip install ${{ inputs.requirements }}
+      - name: 🐍 Update pip
+        run: python -m pip install -U pip
 
-      - name: 🔨 Build Python package (source distribution)
+      # build
+
+      - name: 🔧 [build] Install dependencies for packaging and release
+        if: inputs.requirements == ''
+        run: python -m pip install build
+
+      - name: 🔨 [build] Build Python package (source distribution)
+        if: inputs.requirements == ''
+        run: python -m build --sdist
+
+      - name: 🔨 [build] Build Python package (binary distribution - wheel)
+        if: inputs.requirements == ''
+        run: python -m build --wheel
+
+      # setuptools
+
+      - name: 🔧 [setuptools] Install dependencies for packaging and release
+        if: inputs.requirements != ''
+        run: python -m pip install ${{ inputs.requirements }}
+
+      - name: 🔨 [setuptools] Build Python package (source distribution)
+        if: inputs.requirements != ''
         run: python setup.py sdist
 
-      - name: 🔨 Build Python package (binary distribution - wheel)
+      - name: 🔨 [setuptools] Build Python package (binary distribution - wheel)
+        if: inputs.requirements != ''
         run: python setup.py bdist_wheel
+
 
       - name: 📤 Upload wheel artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -31,7 +31,7 @@ on:
         default: '3.10'
         type: string
       requirements:
-        description: 'Python dependencies to be installed through pip.'
+        description: 'Python dependencies to be installed through pip; if empty, use pyproject.toml through build.'
         required: false
         default: ''
         type: string


### PR DESCRIPTION
Close #20.

# New Features
* Packaging: Support building source and wheel artifacts through `python -m build`.

# Changes
* Packaging: now defaults to using `python -m build`. In order to use `setuptools`, option `requirements.txt` needs to be used.

---

This PR fixes #20. See:

- Without this PR: https://github.com/edaa-org/pyEDAA.ProjectModel/actions/runs/1585021273
- With this PR: https://github.com/edaa-org/pyEDAA.ProjectModel/actions/runs/1586075110
