### PR TITLE
v0.2.2

### DIFF
--- a/.github/workflows/TestReleaser.yml
+++ b/.github/workflows/TestReleaser.yml
@@ -115,6 +115,7 @@ jobs:
       uses: ./releaser/composite
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+        use-gh-cli: true
         files: |
           artifact-*.txt
           README.md

--- a/.github/workflows/TestReleaser.yml
+++ b/.github/workflows/TestReleaser.yml
@@ -39,65 +39,27 @@ env:
 
 jobs:
 
-  test:
+
+  Image:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
     steps:
     - uses: actions/checkout@v2
 
-    - run: echo "Build some tool and generate some (versioned) artifacts" > artifact-$(date -u +"%Y-%m-%dT%H-%M-%SZ").txt
+    - name: Build container image
+      run: docker build -t ghcr.io/pytooling/releaser -f releaser/Dockerfile releaser
 
-    - name: Single
-      uses: ./releaser
+    - name: Push container image
+      uses: ./with-post-step
       with:
-        rm: true
-        token: ${{ secrets.GITHUB_TOKEN }}
-        files: artifact-*.txt
-
-    - name: List
-      uses: ./releaser
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        files: |
-          artifact-*.txt
-          README.md
-
-    - name: Add artifacts/*.txt
-      run: |
-        mkdir artifacts
-        echo "Build some tool and generate some artifacts" > artifacts/artifact.txt
-        touch artifacts/empty_file.txt
-
-    - name: Single in subdir
-      uses: ./releaser
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        files: artifacts/artifact.txt
-
-    - name: Add artifacts/*.md
-      run: |
-        echo "releaser hello" > artifacts/hello.md
-        echo "releaser world" > artifacts/world.md
-
-    - name: Directory wildcard
-      uses: ./releaser
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        files: artifacts/*
-
-    - name: Add artifacts/subdir
-      run: |
-        mkdir artifacts/subdir
-        echo "Test recursive glob" > artifacts/subdir/deep_file.txt
-
-    - name: Directory wildcard (recursive)
-      uses: ./releaser
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        files: artifacts/**
+        main: |
+          echo '${{ github.token }}' | docker login ghcr.io -u GitHub-Actions --password-stdin
+          docker push ghcr.io/pytooling/releaser
+        post: docker logout ghcr.io
 
 
-  test-composite:
-    needs: test
+  Composite:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -153,3 +115,66 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         files: artifacts/**
+
+
+  Test:
+    needs:
+      - Image
+      - Composite
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - run: echo "Build some tool and generate some (versioned) artifacts" > artifact-$(date -u +"%Y-%m-%dT%H-%M-%SZ").txt
+
+    - name: Single
+      uses: ./releaser
+      with:
+        rm: true
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: artifact-*.txt
+
+    - name: List
+      uses: ./releaser
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        use-gh-cli: true
+        files: |
+          artifact-*.txt
+          README.md
+
+    - name: Add artifacts/*.txt
+      run: |
+        mkdir artifacts
+        echo "Build some tool and generate some artifacts" > artifacts/artifact.txt
+        touch artifacts/empty_file.txt
+
+    - name: Single in subdir
+      uses: ./releaser
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: artifacts/artifact.txt
+
+    - name: Add artifacts/*.md
+      run: |
+        echo "releaser hello" > artifacts/hello.md
+        echo "releaser world" > artifacts/world.md
+
+    - name: Directory wildcard
+      uses: ./releaser
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: artifacts/*
+
+    - name: Add artifacts/subdir
+      run: |
+        mkdir artifacts/subdir
+        echo "Test recursive glob" > artifacts/subdir/deep_file.txt
+
+    - name: Directory wildcard (recursive)
+      uses: ./releaser
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        files: artifacts/**
+
+

--- a/.github/workflows/TestReleaser.yml
+++ b/.github/workflows/TestReleaser.yml
@@ -77,7 +77,6 @@ jobs:
       uses: ./releaser/composite
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        use-gh-cli: true
         files: |
           artifact-*.txt
           README.md
@@ -138,7 +137,6 @@ jobs:
       uses: ./releaser
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        use-gh-cli: true
         files: |
           artifact-*.txt
           README.md
@@ -176,5 +174,3 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         files: artifacts/**
-
-

--- a/releaser/Dockerfile
+++ b/releaser/Dockerfile
@@ -1,4 +1,12 @@
 FROM python:3.9-slim-bullseye
 COPY releaser.py /releaser.py
-RUN pip install PyGithub --progress-bar off
+RUN pip install PyGithub --progress-bar off \
+  && apt update -qq \
+  && apt install -y curl \
+  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
+     dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | \
+     tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && apt update -qq \
+  && apt install -y gh
 CMD ["/releaser.py"]

--- a/releaser/README.md
+++ b/releaser/README.md
@@ -149,9 +149,16 @@ Set option `rm` to `true` for systematically removing previous artifacts (e.g. o
 
 Whether to create releases from any tag or to treat some as snapshots. By default, all the tags with non-empty `prerelease` field (see [semver.org: Is there a suggested regular expression (RegEx) to check a SemVer string?](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string)) are considered snapshots; neither a release is created nor assets are uploaded.
 
+### use-gh-cli
+
+In order to work around the reliability issues explained in section *Troubleshooting* above, option *use-gh-cli* allows
+using GitHub's official command line tool ([cli/cli](https://github.com/cli/cli)) for uploading/updating assets.
+
+IMPORTANT: Using this option requires the repository to be cloned (preferredly through [actions/checkout](https://github.com/actions/checkout)).
+
 ## Advanced/complex use cases
 
-**Releaser** is essentially a very fine wrapper to use the GitHub Actions context data along with the classes
+**Releaser** is essentially a very thin wrapper to use the GitHub Actions context data along with the classes
 and methods of PyGithub.
 
 Similarly to [actions/github-script](https://github.com/actions/github-script), users with advanced/complex requirements might find it desirable to write their own Python script, instead of using **Releaser**.

--- a/releaser/README.md
+++ b/releaser/README.md
@@ -6,8 +6,8 @@
 Combined with a workflow that is executed periodically, **Releaser** allows to provide a fixed release name for users willing
 to use daily/nightly artifacts of a project.
 
-Furthermore, when any [semver](https://semver.org) compilant tagged commit is pushed, **Releaser** can create a release and
-upload assets.
+Furthermore, when any [semver](https://semver.org) compilant tagged commit is pushed, **Releaser** can create a release
+and upload assets.
 
 ## Context
 
@@ -17,13 +17,16 @@ GitHub provides official clients for the GitHub API through [github.com/octokit]
 - [octokit.rb](https://github.com/octokit/octokit.rb) ([octokit.github.io/octokit.rb](http://octokit.github.io/octokit.rb))
 - [octokit.net](https://github.com/octokit/octokit.net) ([octokitnet.rtfd.io](https://octokitnet.rtfd.io))
 
-When GitHub Actions was released in 2019, two Actions were made available through [github.com/actions](https://github.com/actions) for dealing with GitHub Releases:
+When GitHub Actions was released in 2019, two Actions were made available through
+[github.com/actions](https://github.com/actions) for dealing with GitHub Releases:
 
 - [actions/create-release](https://github.com/actions/create-release)
 - [actions/upload-release-asset](https://github.com/actions/upload-release-asset)
 
 However, those Actions were contributed by an employee in spare time, not officially supported by GitHub.
-Therefore, they were unmaintained before GitHub Actions was out of the private beta (see [actions/upload-release-asset#58](https://github.com/actions/upload-release-asset/issues/58)) and, a year later, archived.
+Therefore, they were unmaintained before GitHub Actions was out of the private beta
+(see [actions/upload-release-asset#58](https://github.com/actions/upload-release-asset/issues/58))
+and, a year later, archived.
 Those Actions are based on [actions/toolkit](https://github.com/actions/toolkit)'s hydrated version of octokit.js.
 
 From a practical point of view, [actions/github-script](https://github.com/actions/github-script) is the natural replacement to those Actions, since it allows to use a pre-authenticated *octokit.js* client along with the workflow run context.
@@ -80,52 +83,19 @@ jobs:
           README.md
 ```
 
-### Troubleshooting
-
-GitHub's internal connections seem not to be very stable; as a result, uploading artifacts as assets does produce
-failures rather frequently, particularly if large tarballs are to be published.
-When failures are produced, some assets are left in a broken state within the release.
-**Releaser** tries to handle those cases by first uploading assets with a `tmp.*` name and then renaming them; if an existing
-`tmp.*` is found, it is removed and the upload is retried.
-Therefore, restarting the **Releaser** job should suffice for "fixing" a failing run.
-
-Note:
-  Currently, GitHub Actions does not allow restarting a single job.
-  That is unfortunate, because **Releaser** is typically used as the last dependent job in the workflows.
-  Hence, running **Releaser** again requires restarting the whole workflow.
-  Fortunately, restarting individual jobs is expected to be supported on GitHub Actions in the future.
-  See [github/roadmap#271](https://github.com/github/roadmap/issues/271) and [actions/runner#432](https://github.com/actions/runner/issues/432).
-
-If the tip/nightly release generated with **Releaser** is broken, and restarting the run cannot fix it, the recommended
-procedure is the following:
-
-1. Go to `https://github.com/<name>/<repo>/releases/edit/<tag>`.
-2. Edit the assets to:
-  - Remove the ones with a warning symbol and/or named starting with `tmp.*`.
-  - Or, remove all of them.
-3. Save the changes (click the `Update release` button) and restart the **Releaser** job in CI.
-5. If that does still not work, remove the release and restart the **Releaser** job in CI.
-
-See also [eine/tip#160](https://github.com/eine/tip/issues/160).
-
-Note:
-  If all the assets are removed, or if the release itself is removed, tip/nightly assets won't be available for
-  users until the workflow is successfully run.
-  For instance, Action [setup-ghdl-ci](https://github.com/ghdl/setup-ghdl-ci) uses assets from [ghdl/ghdl: releases/tag/nightly](https://github.com/ghdl/ghdl/releases/tag/nightly).
-  Hence, it is recommended to try removing the conflictive assets only, in order to maximise the availability.
-
 ### Composite Action
 
 The default implementation of **Releaser** is a Container Action.
 Therefore, a pre-built container image is pulled before starting the job.
 Alternatively, a Composite Action version is available: `uses: pyTooling/Actions/releaser/composite@main`.
 The Composite version installs the dependencies on the host (the runner environment), instead of using a container.
-Both implementations are functionally equivalent from **Releaser**'s point of view; however, the Composite Action allows users
-to tweak the version of Python by using [actions/setup-python](https://github.com/actions/setup-python) before.
+Both implementations are functionally equivalent from **Releaser**'s point of view; however, the Composite Action allows
+users to tweak the version of Python by using [actions/setup-python](https://github.com/actions/setup-python) before.
 
 ## Options
 
-All options can be optionally provided as environment variables: `INPUT_TOKEN`, `INPUT_FILES`, `INPUT_TAG`, `INPUT_RM` and/or `INPUT_SNAPSHOTS`.
+All options can be optionally provided as environment variables: `INPUT_TOKEN`, `INPUT_FILES`, `INPUT_TAG`, `INPUT_RM`
+and/or `INPUT_SNAPSHOTS`.
 
 ### token (required)
 
@@ -133,7 +103,8 @@ Token to make authenticated API calls; can be passed in using `{{ secrets.GITHUB
 
 ### files (required)
 
-Either a single filename/pattern or a multi-line list can be provided. All the artifacts are uploaded regardless of the hierarchy.
+Either a single filename/pattern or a multi-line list can be provided. All the artifacts are uploaded regardless of the
+hierarchy.
 
 For creating/updating a release without uploading assets, set `files: none`.
 
@@ -143,25 +114,28 @@ The default tag name for the tip/nightly pre-release is `tip`, but it can be opt
 
 ### rm
 
-Set option `rm` to `true` for systematically removing previous artifacts (e.g. old versions). Otherwise (by default), all previours artifacts are preserved or overwritten.
+Set option `rm` to `true` for systematically removing previous artifacts (e.g. old versions).
+Otherwise (by default), all previours artifacts are preserved or overwritten.
+
+Note:
+  If all the assets are removed, or if the release itself is removed, tip/nightly assets won't be available for
+  users until the workflow is successfully run.
+  For instance, Action [setup-ghdl-ci](https://github.com/ghdl/setup-ghdl-ci) uses assets from [ghdl/ghdl: releases/tag/nightly](https://github.com/ghdl/ghdl/releases/tag/nightly).
+  Hence, it is recommended to try removing the conflictive assets only, in order to maximise the availability.
 
 ### snapshots
 
-Whether to create releases from any tag or to treat some as snapshots. By default, all the tags with non-empty `prerelease` field (see [semver.org: Is there a suggested regular expression (RegEx) to check a SemVer string?](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string)) are considered snapshots; neither a release is created nor assets are uploaded.
-
-### use-gh-cli
-
-In order to work around the reliability issues explained in section *Troubleshooting* above, option *use-gh-cli* allows
-using GitHub's official command line tool ([cli/cli](https://github.com/cli/cli)) for uploading/updating assets.
-
-IMPORTANT: Using this option requires the repository to be cloned (preferredly through [actions/checkout](https://github.com/actions/checkout)).
+Whether to create releases from any tag or to treat some as snapshots.
+By default, all the tags with non-empty `prerelease` field (see [semver.org: Is there a suggested regular expression (RegEx) to check a SemVer string?](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string))
+are considered snapshots; neither a release is created nor assets are uploaded.
 
 ## Advanced/complex use cases
 
 **Releaser** is essentially a very thin wrapper to use the GitHub Actions context data along with the classes
 and methods of PyGithub.
 
-Similarly to [actions/github-script](https://github.com/actions/github-script), users with advanced/complex requirements might find it desirable to write their own Python script, instead of using **Releaser**.
+Similarly to [actions/github-script](https://github.com/actions/github-script), users with advanced/complex requirements
+might find it desirable to write their own Python script, instead of using **Releaser**.
 In fact, since `shell: python` is supported in GitHub Actions, using Python does *not* require any Action.
 For prototyping purposes, the following job might be useful:
 

--- a/releaser/README.md
+++ b/releaser/README.md
@@ -26,7 +26,7 @@ However, those Actions were contributed by an employee in spare time, not offici
 Therefore, they were unmaintained before GitHub Actions was out of the private beta (see [actions/upload-release-asset#58](https://github.com/actions/upload-release-asset/issues/58)) and, a year later, archived.
 Those Actions are based on [actions/toolkit](https://github.com/actions/toolkit)'s hydrated version of octokit.js.
 
-From a practical point of view, [actions/github-script](https://github.com/actions/github-script) is the natural replacement to those Actions, since it allows to use a pre-authenticated octokit.js client along with the workflow run context.
+From a practical point of view, [actions/github-script](https://github.com/actions/github-script) is the natural replacement to those Actions, since it allows to use a pre-authenticated *octokit.js* client along with the workflow run context.
 Still, it requires writing plain JavaScript.
 
 Alternatively, there are non-official GitHub API libraries available in other languages (see [docs.github.com: rest/overview/libraries](https://docs.github.com/en/rest/overview/libraries)).
@@ -72,7 +72,7 @@ jobs:
     # Update tag and pre-release
     # - Update (force-push) tag to the commit that is used in the workflow.
     # - Upload artifacts defined by the user.
-    - uses: pyTooling/Actions/releaser@main
+    - uses: pyTooling/Actions/releaser@r0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         files: |
@@ -117,7 +117,7 @@ Note:
 ### Composite Action
 
 The default implementation of **Releaser** is a Container Action.
-Therefore, in each run, the container image is built before starting the job.
+Therefore, a pre-built container image is pulled before starting the job.
 Alternatively, a Composite Action version is available: `uses: pyTooling/Actions/releaser/composite@main`.
 The Composite version installs the dependencies on the host (the runner environment), instead of using a container.
 Both implementations are functionally equivalent from **Releaser**'s point of view; however, the Composite Action allows users

--- a/releaser/action.yml
+++ b/releaser/action.yml
@@ -40,10 +40,6 @@ inputs:
     description: 'Whether to create releases from any tag or to treat some as snapshots'
     required: false
     default: true
-  use-gh-cli:
-    description: 'Whether to use the GitHub CLI for uploading artifacts (requires actions/checkout)'
-    required: false
-    default: false
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/pytooling/releaser'

--- a/releaser/action.yml
+++ b/releaser/action.yml
@@ -46,4 +46,4 @@ inputs:
     default: false
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/pytooling/releaser'

--- a/releaser/action.yml
+++ b/releaser/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: 'Whether to create releases from any tag or to treat some as snapshots'
     required: false
     default: true
+  use-gh-cli:
+    description: 'Whether to use the GitHub CLI for uploading artifacts (requires actions/checkout)'
+    required: false
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/releaser/composite/action.yml
+++ b/releaser/composite/action.yml
@@ -40,10 +40,6 @@ inputs:
     description: 'Whether to create releases from any tag or to treat some as snapshots'
     required: false
     default: true
-  use-gh-cli:
-    description: 'Whether to use the GitHub CLI for uploading artifacts (requires actions/checkout)'
-    required: false
-    default: false
 runs:
   using: 'composite'
   steps:
@@ -59,4 +55,3 @@ runs:
       INPUT_TAG: ${{ inputs.tag }}
       INPUT_RM: ${{ inputs.rm }}
       INPUT_SNAPSHOTS: ${{ inputs.snapshots }}
-      INPUT_USE-GH-CLI: ${{ inputs.use-gh-cli }}

--- a/releaser/composite/action.yml
+++ b/releaser/composite/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: 'Whether to create releases from any tag or to treat some as snapshots'
     required: false
     default: true
+  use-gh-cli:
+    description: 'Whether to use the GitHub CLI for uploading artifacts (requires actions/checkout)'
+    required: false
+    default: false
 runs:
   using: 'composite'
   steps:
@@ -55,3 +59,4 @@ runs:
       INPUT_TAG: ${{ inputs.tag }}
       INPUT_RM: ${{ inputs.rm }}
       INPUT_SNAPSHOTS: ${{ inputs.snapshots }}
+      INPUT_USE-GH-CLI: ${{ inputs.use-gh-cli }}

--- a/releaser/releaser.py
+++ b/releaser/releaser.py
@@ -81,13 +81,6 @@ def GetGitHubAPIHandler():
 
 
 def GetReleaseHandler(gh):
-    def GetRepositoryHandler(repo):
-        print("· Get Repository handler")
-        if repo is None:
-            stdout.flush()
-            raise (Exception("Repository name not defined! Please set 'GITHUB_REPOSITORY"))
-        return gh.get_repo(repo)
-
     def CheckRefSemVer(gh_ref, tag):
         print("· Check SemVer compliance of the reference/tag")
         env_tag = None
@@ -113,8 +106,15 @@ def GetReleaseHandler(gh):
                         sys_exit()
         return (tag, env_tag, True)
 
-    gh_repo = GetRepositoryHandler(getenv("GITHUB_REPOSITORY", None))
+    def GetRepositoryHandler(repo):
+        print("· Get Repository handler")
+        if repo is None:
+            stdout.flush()
+            raise (Exception("Repository name not defined! Please set 'GITHUB_REPOSITORY"))
+        return gh.get_repo(repo)
+
     [tag, env_tag, is_prerelease] = CheckRefSemVer(environ["GITHUB_REF"], getenv("INPUT_TAG", "tip"))
+    gh_repo = GetRepositoryHandler(getenv("GITHUB_REPOSITORY", None))
 
     print("· Get Release handler")
 

--- a/releaser/releaser.py
+++ b/releaser/releaser.py
@@ -62,24 +62,27 @@ def GetListOfArtifacts(argv):
         return files
 
 
-files = GetListOfArtifacts(sys_argv)
+def GetGitHubAPIHandler():
+    print("· Get GitHub API handler (authenticate)")
 
-
-print("· Get GitHub API handler (authenticate)")
-
-if "GITHUB_TOKEN" in environ:
-    gh = Github(environ["GITHUB_TOKEN"])
-elif "INPUT_TOKEN" in environ:
-    gh = Github(environ["INPUT_TOKEN"])
-else:
-    if "GITHUB_USER" not in environ or "GITHUB_PASS" not in environ:
-        stdout.flush()
-        raise (
-            Exception(
-                "Need credentials to authenticate! Please, provide 'GITHUB_TOKEN', 'INPUT_TOKEN', or 'GITHUB_USER' and 'GITHUB_PASS'"
+    if "GITHUB_TOKEN" in environ:
+        return Github(environ["GITHUB_TOKEN"])
+    elif "INPUT_TOKEN" in environ:
+        return Github(environ["INPUT_TOKEN"])
+    else:
+        if "GITHUB_USER" not in environ or "GITHUB_PASS" not in environ:
+            stdout.flush()
+            raise (
+                Exception(
+                    "Need credentials to authenticate! Please, provide 'GITHUB_TOKEN', 'INPUT_TOKEN', or 'GITHUB_USER' and 'GITHUB_PASS'"
+                )
             )
-        )
-    gh = Github(environ["GITHUB_USER"], environ["GITHUB_PASS"])
+        return Github(environ["GITHUB_USER"], environ["GITHUB_PASS"])
+
+
+files = GetListOfArtifacts(sys_argv)
+gh = GetGitHubAPIHandler()
+
 
 print("· Get Repository handler")
 

--- a/releaser/releaser.py
+++ b/releaser/releaser.py
@@ -81,13 +81,12 @@ def GetGitHubAPIHandler():
 
 
 def GetReleaseHandler(gh):
-    print("· Get Repository handler")
-
-    if "GITHUB_REPOSITORY" not in environ:
-        stdout.flush()
-        raise (Exception("Repository name not defined! Please set 'GITHUB_REPOSITORY"))
-
-    gh_repo = gh.get_repo(environ["GITHUB_REPOSITORY"])
+    def GetRepositoryHandler(repo):
+        print("· Get Repository handler")
+        if repo is None:
+            stdout.flush()
+            raise (Exception("Repository name not defined! Please set 'GITHUB_REPOSITORY"))
+        return gh.get_repo(repo)
 
     def CheckRefSemVer(gh_ref, tag):
         print("· Check SemVer compliance of the reference/tag")
@@ -114,6 +113,7 @@ def GetReleaseHandler(gh):
                         sys_exit()
         return (tag, env_tag, True)
 
+    gh_repo = GetRepositoryHandler(getenv("GITHUB_REPOSITORY", None))
     [tag, env_tag, is_prerelease] = CheckRefSemVer(environ["GITHUB_REF"], getenv("INPUT_TAG", "tip"))
 
     print("· Get Release handler")


### PR DESCRIPTION
# New Features
* *None*

# Changes
* Action *releaser*:
  * Refactor.
  * Build a container image in workflow `TestReleaser.yml` and push it to `ghcr.io/pytooling/releaser` using the default `github.token`.
  * Make the Container Action use the pre-built container image, instead of the Dockerfile.
  * Use GitHub's official CLI to upload (and replace) release assets, instead of PyGitHub's methods. See [cli.github.com/manual/gh_release_upload](https://cli.github.com/manual/gh_release_upload) and eine/tip#160.
  * The *Troubleshooting* section of the README was removed.

# Bug Fixes
* *None*

---

Using GitHub's CLI should fix the reliability issues. That was successfully tested in org msys2, in NEORV32 and in GHDL. It is also surprisingly fast, compared to PyGitHub. Note that PyGitHub is still used to create or update the release, and to update the reference/tag (a feature not supported by GitHub's CLI).
