### PR TITLE
Pytest using pyproject.toml.

### DIFF
--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -66,23 +66,40 @@ jobs:
 
       - name: 🔁 Extract configurations from pyproject.toml
         id: getVariables
+        shell: python
         run: |
-          function ReadToml() {
-            state=0;
-            RegExp="$2 = \"(.*)\""
-            while IFS=$'\r\n' read -r Line; do
-                if [[ $state -eq 0 && "$Line" == "[$1]" ]]; then
-                    state=1;
-                elif [[ $state -eq 1 && "$Line" =~ $RegExp ]]; then
-                    echo "${BASH_REMATCH[1]}";
-                    break;
-                fi
-            done < <(cat "pyproject.toml")
-          }
+          from pathlib import Path
+          from tomli   import load as tomli_load
           
-          # write to step outputs
-          echo ::set-output name=coverage_report_html_directory::$(ReadToml "tool.coverage.html" "directory")
-          echo ::set-output name=coverage_report_xml::$(ReadToml "tool.coverage.xml" "output")
+          coverageRC = "${{ inputs.coverage_config }}".strip()
+
+          # Read output paths from 'pyproject.toml' file
+          if coverageRC == "":
+              pyProjectFile =  Path("pyproject.toml")
+              if pyProjectFile.exists():
+                  with pyProjectFile.open("rb") as file:
+                      pyProjectSettings = tomli_load(file)
+                  
+                  htmlDirectory = pyProjectSettings["tool.coverage.html"]["directory"]
+                  xmlFile       = pyProjectSettings["tool.coverage.xml"]["output"]
+              else:
+                  print(f"File '{pyProjectFile}' not found and no ' .coveragerc' file specified.")
+          
+          # Read output paths from '.coveragerc' file
+          else:
+              coverageRCFile = Path(coverageRC)
+              if coverageRCFile.exists():
+                  with coverageRCFile.open("rb") as file:
+                      coverageRCSettings = tomli_load(file)
+                  
+                  htmlDirectory = pyProjectSettings["html"]["directory"]
+                  xmlFile       = pyProjectSettings["xml"]["output"]
+              else:
+                  print(f"File '{coverageRCFile}' not found.")
+          
+          print(f"::set-output name=coverage_report_html_directory::{htmlDirectory}")
+          print(f"::set-output name=coverage_report_xml::{xmlFile}")
+          print(f"DEBUG:\n  html={htmlDirectory}\n  xml={xmlFile}")
 
       - name: 🐍 Setup Python ${{ inputs.python_version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -64,6 +64,26 @@ jobs:
       - name: ⏬ Checkout repository
         uses: actions/checkout@v2
 
+      - name: 🔁 Extract configurations from pyproject.toml
+        id: getVariables
+        run: |
+          function ReadToml() {
+            state=0;
+            RegExp="$2 = \"(.*)\""
+            while IFS=$'\r\n' read -r Line; do
+                if [[ $state -eq 0 && "$Line" == "[$1]" ]]; then
+                    state=1;
+                elif [[ $state -eq 1 && "$Line" =~ $RegExp ]]; then
+                    echo "${BASH_REMATCH[1]}";
+                    break;
+                fi
+            done < <(cat "pyproject.toml")
+          }
+          
+          # write to step outputs
+          echo ::set-output name=coverage_report_html_directory::$(ReadToml "tool.coverage.html" "directory")
+          echo ::set-output name=coverage_report_xml::$(ReadToml "tool.coverage.xml" "output")
+
       - name: 🐍 Setup Python ${{ inputs.python_version }}
         uses: actions/setup-python@v2
         with:
@@ -86,14 +106,14 @@ jobs:
       - name: Convert to HTML format
         run: |
           coverage html
-          rm report/coverage/html/.gitignore
+          rm ${{ steps.getVariables.outputs.coverage_report_html_directory }}/.gitignore
 
       - name: 📤 Upload 'Coverage Report' artifact
         continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
           name: ${{ inputs.artifact }}
-          path: report/coverage/html
+          path: ${{ steps.getVariables.outputs.coverage_report_html_directory }}
           if-no-files-found: error
           retention-days: 1
 
@@ -101,7 +121,7 @@ jobs:
         continue-on-error: true
         uses: codecov/codecov-action@v1
         with:
-          file: report/coverage/coverage.xml
+          file: ${{ steps.getVariables.outputs.coverage_report_xml }}
           flags: unittests
           env_vars: PYTHON
 
@@ -110,4 +130,4 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@master
         with:
           project-token: ${{ secrets.codacy_token }}
-          coverage-reports: report/coverage/coverage.xml
+          coverage-reports: ${{ steps.getVariables.outputs.coverage_report_xml }}

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           from pathlib import Path
           from tomli   import load as tomli_load
-          
+
           coverageRC = "${{ inputs.coverage_config }}".strip()
 
           # Read output paths from 'pyproject.toml' file
@@ -90,24 +90,24 @@ jobs:
               if pyProjectFile.exists():
                   with pyProjectFile.open("rb") as file:
                       pyProjectSettings = tomli_load(file)
-                  
+
                   htmlDirectory = pyProjectSettings["tool"]["coverage"]["html"]["directory"]
                   xmlFile       = pyProjectSettings["tool"]["coverage"]["xml"]["output"]
               else:
                   print(f"File '{pyProjectFile}' not found and no ' .coveragerc' file specified.")
-          
+
           # Read output paths from '.coveragerc' file
           else:
               coverageRCFile = Path(coverageRC)
               if coverageRCFile.exists():
                   with coverageRCFile.open("rb") as file:
                       coverageRCSettings = tomli_load(file)
-                  
-                  htmlDirectory = pyProjectSettings["html"]["directory"]
-                  xmlFile       = pyProjectSettings["xml"]["output"]
+
+                  htmlDirectory = coverageRCSettings["html"]["directory"]
+                  xmlFile       = coverageRCSettings["xml"]["output"]
               else:
                   print(f"File '{coverageRCFile}' not found.")
-          
+
           print(f"::set-output name=coverage_report_html_directory::{htmlDirectory}")
           print(f"::set-output name=coverage_report_xml::{xmlFile}")
           print(f"DEBUG:\n  html={htmlDirectory}\n  xml={xmlFile}")

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -98,7 +98,7 @@ jobs:
         continue-on-error: true
         run: |
           [ 'x${{ inputs.coverage_config }}' != 'x' ] && PYCOV_ARGS='--cov-config=${{ inputs.coverage_config }}' || unset PYCOV_ARGS
-          python -m pytest -rA --cov=.. $PYCOV_ARGS ${{ inputs.unittest_directory }} --color=yes
+          python -m pytest -rA --cov=. $PYCOV_ARGS ${{ inputs.unittest_directory }} --color=yes
 
       - name: Convert to cobertura format
         run: coverage xml

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -64,6 +64,17 @@ jobs:
       - name: ⏬ Checkout repository
         uses: actions/checkout@v2
 
+      - name: 🐍 Setup Python ${{ inputs.python_version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: 🗂 Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install tomli
+          python -m pip install ${{ inputs.requirements }}
+
       - name: 🔁 Extract configurations from pyproject.toml
         id: getVariables
         shell: python
@@ -100,16 +111,6 @@ jobs:
           print(f"::set-output name=coverage_report_html_directory::{htmlDirectory}")
           print(f"::set-output name=coverage_report_xml::{xmlFile}")
           print(f"DEBUG:\n  html={htmlDirectory}\n  xml={xmlFile}")
-
-      - name: 🐍 Setup Python ${{ inputs.python_version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ inputs.python_version }}
-
-      - name: 🗂 Install dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install ${{ inputs.requirements }}
 
       - name: Collect coverage
         continue-on-error: true

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Convert to HTML format
         run: |
-          coverage html
+          coverage html -d ${{ steps.getVariables.outputs.coverage_report_html_directory }}
           rm ${{ steps.getVariables.outputs.coverage_report_html_directory }}/.gitignore
 
       - name: 📤 Upload 'Coverage Report' artifact

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -99,7 +99,7 @@ jobs:
                   print(f"File '{pyProjectFile}' not found and no ' .coveragerc' file specified.")
 
           # Read output paths from '.coveragerc' file
-          else:
+          elif len(coverageRC) > 0:
               coverageRCFile = Path(coverageRC)
               if coverageRCFile.exists():
                   with coverageRCFile.open("rb") as file:

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -91,8 +91,8 @@ jobs:
                   with pyProjectFile.open("rb") as file:
                       pyProjectSettings = tomli_load(file)
                   
-                  htmlDirectory = pyProjectSettings["tool.coverage.html"]["directory"]
-                  xmlFile       = pyProjectSettings["tool.coverage.xml"]["output"]
+                  htmlDirectory = pyProjectSettings["tool"]["coverage"]["html"]["directory"]
+                  xmlFile       = pyProjectSettings["tool"]["coverage"]["xml"]["output"]
               else:
                   print(f"File '{pyProjectFile}' not found and no ' .coveragerc' file specified.")
           

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -35,6 +35,16 @@ on:
         required: false
         default: '-r tests/requirements.txt'
         type: string
+      unittest_directory:
+        description: 'Path to the directory containing unit tests.'
+        required: false
+        default: 'tests/unit'
+        type: string
+      coverage_config:
+        description: 'Path to the .coveragerc file. Use pyproject.toml if empty.'
+        required: false
+        default: ''
+        type: string
       artifact:
         description: 'Name of the coverage artifact.'
         required: true
@@ -67,7 +77,8 @@ jobs:
       - name: Collect coverage
         continue-on-error: true
         run: |
-          python -m pytest -rA --cov=.. --cov-config=tests/.coveragerc tests/unit --color=yes
+          [ 'x${{ inputs.coverage_config }}' != 'x' ] && PYCOV_ARGS='--cov-config=${{ inputs.coverage_config }}' || unset PYCOV_ARGS
+          python -m pytest -rA --cov=.. $PYCOV_ARGS ${{ inputs.unittest_directory }} --color=yes
 
       - name: Convert to cobertura format
         run: coverage xml
@@ -75,14 +86,14 @@ jobs:
       - name: Convert to HTML format
         run: |
           coverage html
-          rm htmlcov/.gitignore
+          rm report/coverage/html/.gitignore
 
       - name: 📤 Upload 'Coverage Report' artifact
         continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
           name: ${{ inputs.artifact }}
-          path: htmlcov
+          path: report/coverage/html
           if-no-files-found: error
           retention-days: 1
 
@@ -90,7 +101,7 @@ jobs:
         continue-on-error: true
         uses: codecov/codecov-action@v1
         with:
-          file: ./coverage.xml
+          file: report/coverage/coverage.xml
           flags: unittests
           env_vars: PYTHON
 
@@ -99,4 +110,4 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@master
         with:
           project-token: ${{ secrets.codacy_token }}
-          coverage-reports: ./coverage.xml
+          coverage-reports: report/coverage/coverage.xml

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -41,9 +41,9 @@ on:
         default: 'tests/unit'
         type: string
       coverage_config:
-        description: 'Path to the .coveragerc file. Use pyproject.toml if empty.'
+        description: 'Path to the .coveragerc file. Use pyproject.toml by default.'
         required: false
-        default: ''
+        default: 'pyproject.toml'
         type: string
       artifact:
         description: 'Name of the coverage artifact.'
@@ -87,7 +87,7 @@ jobs:
           coverageRC = "${{ inputs.coverage_config }}".strip()
 
           # Read output paths from 'pyproject.toml' file
-          if coverageRC == "":
+          if coverageRC == "pyproject.toml":
               pyProjectFile =  Path("pyproject.toml")
               if pyProjectFile.exists():
                   with pyProjectFile.open("rb") as file:

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -82,6 +82,7 @@ jobs:
           from pathlib import Path
           from tomli   import load as tomli_load
 
+          htmlDirectory = 'htmlcov'
           coverageRC = "${{ inputs.coverage_config }}".strip()
 
           # Read output paths from 'pyproject.toml' file

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -83,6 +83,7 @@ jobs:
           from tomli   import load as tomli_load
 
           htmlDirectory = 'htmlcov'
+          xmlFile = './coverage.xml'
           coverageRC = "${{ inputs.coverage_config }}".strip()
 
           # Read output paths from 'pyproject.toml' file

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -76,7 +76,7 @@ jobs:
           print(params)
 
           data = {
-             '3.6': { 'icon': '🔴', 'until': '23.12.2021' },
+             '3.6': { 'icon': '🔴', 'until': '23.12.2021' },   # Black circle ⚫ for EOL versions.
              '3.7': { 'icon': '🟠', 'until': '27.06.2023' },
              '3.8': { 'icon': '🟡', 'until': 'Oct. 2024' },
              '3.9': { 'icon': '🟢', 'until': 'Oct. 2025' },

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -34,6 +34,11 @@ on:
         required: false
         default: '-r tests/requirements.txt'
         type: string
+      unittest_directory:
+        description: 'Path to the directory containing unit tests.'
+        required: false
+        default: 'tests/unit'
+        type: string
       artifact:
         description: "Generate unit test report with junitxml and upload results as an artifact."
         required: false
@@ -68,7 +73,7 @@ jobs:
       - name: ☑ Run unit tests
         run: |
           [ 'x${{ inputs.artifact }}' != 'x' ] && PYTEST_ARGS='--junitxml=TestReport.xml' || unset PYTEST_ARGS
-          python -m pytest -rA tests/unit $PYTEST_ARGS --color=yes
+          python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
 
       - name: 📤 Upload 'TestReport.xml' artifact
         if: inputs.artifact != ''

--- a/README.md
+++ b/README.md
@@ -95,13 +95,16 @@ As shown in the screenshot above, the expected order is:
 - Global:
   - [Parameters](.github/workflows/Parameters.yml): a workaround for the limitations to handle global variables in
     GitHub Actions workflows (see [actions/runner#480](https://github.com/actions/runner/issues/480)).
-    It generates outputs with artifact names and job matrices to be used in other jobs.
+    It generates outputs with artifact names and job matrices to be used in later running jobs.
 - Code testing/analysis:
   - [UnitTesting](.github/workflows/UnitTesting.yml): run unit test with `pytest` using multiple versions of Python, and
-    optionally upload results as XML reports.
-  - [CoverageCollection](.github/workflows/CoverageCollection.yml): collect coverage data with `pytest` using a single
-    version of Python, generate HTML and Cobertura (XML) reports, upload the HTML report as an artifact, and upload the
-    results to Codecov and Codacy.
+    optionally upload results as XML reports. Configuration options to `pytest` should be given via section
+   `[tool.pytest.ini_options]` in a `pyproject.toml` file.
+  - [CoverageCollection](.github/workflows/CoverageCollection.yml): collect code coverage data (incl. branch coverage)
+    with `pytest`/`pytest-cov`/`coverage.py` using a single version of Python (latest). It generates HTML and Cobertura
+    (XML)reports, upload the HTML report as an artifact, and upload the test results to Codecov and Codacy. Configuration
+    options to `pytest` and `coverage.py` should be given via section `[tool.pytest.ini_options]` and `[tool.coverage.*]`
+    in a `pyproject.toml` file.
   - [StaticTypeCheck](.github/workflows/StaticTypeCheck.yml): collect static type check result with `mypy`, and
     optionally upload results as an HTML report.
     Example `commands`:
@@ -128,7 +131,7 @@ As shown in the screenshot above, the expected order is:
         mypy --html-report ../htmlmypy -p ToolName
       ```
 
-  - [VerifyDocs](.github/workflows/VerifyDocs.yml): extract code examples from the README and test.
+  - [VerifyDocs](.github/workflows/VerifyDocs.yml): extract code examples from the README and test these code snippets.
 - Packaging and releasing:
   - [Release](.github/workflows/Release.yml): publish GitHub Release.
   - [Package](.github/workflows/Package.yml): generate source and wheel packages, and upload them as an artifact.


### PR DESCRIPTION
# New Features
* Allow configuration of the unit test directory (default: `tests/unit`).
* Allow configuration of a `pyproject.toml` or `.coveragerc` file.
* Extract values from `pyproject.toml` or `.coveragerc`.

# Changes
* Jobs deriving from template job `CoverageCollection` need to specify their `.coveragerc` content and `pytest.ini` content in a `pyproject.toml` file or provide the job parameter `coverage_config` with the path to the `.coveragerc` file.

# Bug Fixes
*None*

-------------
* Closes #2.