### PR TITLE
Extend Unit Tests to multiple systems (ubuntu, windows, msys2 and macos)

### DIFF
--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -83,7 +83,9 @@ jobs:
           systems = '${{ inputs.system_list }}'.split(' ')
           versions = '${{ inputs.python_version_list }}'.split(' ')
           if '3.6' in versions:
-              print('WARNING: support for Python 3.6 ended in 2021.12.23')
+              print("::warning title=Deprecated::Support for Python 3.6 ended in 2021.12.23.")
+          if '3.11' in versions:
+              print(f"::notice title=Experimental::Python 3.11 (3.11.0-alpha3) is a pre-release.")
           data = {
               'python': {
                   '3.6':  { 'icon': '⚫', 'until': '2021.12.23' },

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -33,7 +33,7 @@ on:
       python_version_list:
         description: 'Space separated list of Python versions to run tests with.'
         required: false
-        default: '3.6 3.7 3.8 3.9 3.10'
+        default: '3.7 3.8 3.9 3.10'
         type: string
       name:
         description: 'Name of the tool.'

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -38,7 +38,7 @@ on:
       system_list:
         description: 'Space separated list of systems to run tests on.'
         required: false
-        default: 'ubuntu windows macos'
+        default: 'ubuntu windows msys2 macos'
         type: string
       name:
         description: 'Name of the tool.'
@@ -93,20 +93,23 @@ jobs:
                  '3.10': { 'icon': '🟢', 'until': '2026.10' },
               },
               'sys': {
-                  'ubuntu': '🐧',
-                  'windows': '🧊',
-                  'macos': '🍎',
+                  'ubuntu':  { 'icon': '🐧', 'runs-on': 'ubuntu-latest',  'shell': 'bash' },
+                  'windows': { 'icon': '🧊', 'runs-on': 'windows-latest', 'shell': 'pwsh' },
+                  'msys2':   { 'icon': '🟦', 'runs-on': 'windows-latest', 'shell': 'msys2 {0}' },
+                  'macos':   { 'icon': '🍎', 'runs-on': 'macos-latest',   'shell': 'bash' }
               }
           }
           jobs = [
               {
-                  'sysicon': data['sys'][system],
+                  'sysicon': data['sys'][system]['icon'],
                   'system': system,
+                  'runs-on': data['sys'][system]['runs-on'],
+                  'shell': data['sys'][system]['shell'],
                   'pyicon': data['python'][version]['icon'],
                   'python': version
               }
               for system in systems
-              for version in versions
+              for version in (versions if system != 'msys2' else ['3.9'])
           ]
           print(f'::set-output name=python_jobs::{jobs!s}')
           print("Python jobs:")

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -35,6 +35,11 @@ on:
         required: false
         default: '3.7 3.8 3.9 3.10'
         type: string
+      system_list:
+        description: 'Space separated list of systems to run tests on.'
+        required: false
+        default: 'ubuntu windows macos'
+        type: string
       name:
         description: 'Name of the tool.'
         required: true
@@ -75,18 +80,32 @@ jobs:
           print("Parameters:")
           print(params)
 
+          systems = '${{ inputs.system_list }}'.split(' ')
           versions = '${{ inputs.python_version_list }}'.split(' ')
           if '3.6' in versions:
               print('WARNING: support for Python 3.6 ended in 2021.12.23')
           data = {
-             '3.6': { 'icon': '⚫', 'until': '2021.12.23' },
-             '3.7': { 'icon': '🔴', 'until': '2023.06.27' },
-             '3.8': { 'icon': '🟠', 'until': '2024.10' },
-             '3.9': { 'icon': '🟡', 'until': '2025.10' },
-            '3.10': { 'icon': '🟢', 'until': '2026.10' },
+              'python': {
+                  '3.6': { 'icon': '⚫', 'until': '2021.12.23' },
+                  '3.7': { 'icon': '🔴', 'until': '2023.06.27' },
+                  '3.8': { 'icon': '🟠', 'until': '2024.10' },
+                  '3.9': { 'icon': '🟡', 'until': '2025.10' },
+                 '3.10': { 'icon': '🟢', 'until': '2026.10' },
+              },
+              'sys': {
+                  'ubuntu': '🐧',
+                  'windows': '🧊',
+                  'macos': '🍎',
+              }
           }
           jobs = [
-              {'python': version, 'icon': data[version]['icon']}
+              {
+                  'sysicon': data['sys'][system],
+                  'system': system,
+                  'pyicon': data['python'][version]['icon'],
+                  'python': version
+              }
+              for system in systems
               for version in versions
           ]
           print(f'::set-output name=python_jobs::{jobs!s}')

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -36,7 +36,7 @@ on:
         default: '3.6 3.7 3.8 3.9 3.10'
         type: string
       name:
-        description: 'Name of the tool/package.'
+        description: 'Name of the tool.'
         required: true
         type: string
     outputs:

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -44,11 +44,6 @@ on:
         description: 'Commands to run the static type checks.'
         required: true
         type: string
-      allow_failure:
-        description: 'Allow a type checking to be failing without failing the overall workflow.'
-        required: false
-        default: false
-        type: boolean
       artifact:
         description: 'Name of the typing artifact.'
         required: true
@@ -75,12 +70,12 @@ jobs:
           python -m pip install ${{ inputs.requirements }}
 
       - name: Check Static Typing
-        continue-on-error: ${{ inputs.allow_failure }}
+        continue-on-error: true
         run: ${{ inputs.commands }}
 
       - name: 📤 Upload 'Static Typing Report' artifact
         if: ${{ inputs.artifact != '' }}
-        continue-on-error: ${{ inputs.allow_failure }}
+        continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
           name: ${{ inputs.artifact }}

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -48,8 +48,8 @@ on:
 jobs:
 
   UnitTesting:
-    name: ${{ matrix.icon }} Unit Tests using Python ${{ matrix.python }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.sysicon }} ${{ matrix.pyicon }} Unit Tests using Python ${{ matrix.python }}
+    runs-on: ${{ matrix.system }}-latest
 
     strategy:
       fail-fast: false
@@ -71,6 +71,7 @@ jobs:
           python -m pip install ${{ inputs.requirements }}
 
       - name: ☑ Run unit tests
+        shell: bash
         run: |
           [ 'x${{ inputs.artifact }}' != 'x' ] && PYTEST_ARGS='--junitxml=TestReport.xml' || unset PYTEST_ARGS
           python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
@@ -79,7 +80,7 @@ jobs:
         if: inputs.artifact != ''
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ inputs.artifact }}-${{ matrix.python }}
+          name: ${{ inputs.artifact }}-${{ matrix.system }}-${{ matrix.python }}
           path: TestReport.xml
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -26,7 +26,7 @@ on:
   workflow_call:
     inputs:
       jobs:
-        description: 'JSON list with field <python>, telling the versions to run tests with.'
+        description: 'JSON list with environment fields, telling the system and Python versions to run tests with.'
         required: true
         type: string
       requirements:

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -49,18 +49,31 @@ jobs:
 
   UnitTesting:
     name: ${{ matrix.sysicon }} ${{ matrix.pyicon }} Unit Tests using Python ${{ matrix.python }}
-    runs-on: ${{ matrix.system }}-latest
+    runs-on: ${{ matrix.runs-on }}
 
     strategy:
       fail-fast: false
       matrix:
         include: ${{ fromJson(inputs.jobs) }}
 
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+
     steps:
       - name: ⏬ Checkout repository
         uses: actions/checkout@v2
 
-      - name: 🐍 Setup Python ${{ matrix.python }}
+      - if: matrix.system == 'msys2'
+        name: '🟦 Setup MSYS2'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          pacboy: python-pip:p
+
+      - if: matrix.system != 'msys2'
+        name: 🐍 Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
@@ -71,7 +84,6 @@ jobs:
           python -m pip install ${{ inputs.requirements }}
 
       - name: ☑ Run unit tests
-        shell: bash
         run: |
           [ 'x${{ inputs.artifact }}' != 'x' ] && PYTEST_ARGS='--junitxml=TestReport.xml' || unset PYTEST_ARGS
           python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -34,7 +34,7 @@ jobs:
     with:
       name: ToolName
       # Optional
-      system_list: 'ubuntu windows macos'
+      system_list: 'ubuntu windows msys2 macos'
       python_version: '3.10'
       python_version_list: '3.8 3.9 3.10'
 

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -70,6 +70,7 @@ jobs:
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       requirements: '-r tests/requirements.txt'
       report: 'htmlmypy'
+      allow_failure: true
 
   PublishTestResults:
     uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@main

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -34,6 +34,7 @@ jobs:
     with:
       name: ToolName
       # Optional
+      system_list: 'ubuntu windows macos'
       python_version: '3.10'
       python_version_list: '3.8 3.9 3.10'
 


### PR DESCRIPTION
# New Features

* Added support for Python 3.11 pre-release versions.
* Support execution on Linux (Ubuntu), macOS and Windows.
* Support for MSYS2-MinGW64.
* Use GitHub `warning` and `notice` to tell about using Python 3.6 or 3.11.

# Changes

* Parameters: remove 3.6 from default python_version_list.
* Parameters: add option 'system_list'; UnitTesting now requires field 'system' in the matrix.
* Parameters: support system 'msys2' (MINGW64); update UnitTesting accordingly.
* Split requirements installation into a MSYS2 specific and common step.
  * Preinstall Python packages not installed on MSYS2-MinGW64 by default (wheel)
  * Preinstall packages with binary content (Coverage, lxml) via Pacman.

# Bug Fixes

*None*

---------------
**Related PRs:**
* #34
* #35
* #36