### PR TITLE
Workarounds for MSYS2-MinGW64 (pacman)

### DIFF
--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -79,8 +79,18 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: 🔧 Install dependencies
+        if: matrix.system != 'msys2'
         run: |
           python -m pip install -U pip wheel
+          python -m pip install ${{ inputs.requirements }}
+
+      - name: 🔧 Install dependencies
+        if: matrix.system == 'msys2'
+        run: |
+          pacman -S --noconfirm mingw64/mingw-w64-x86_64-python-wheel
+          pacman -S --noconfirm mingw64/mingw-w64-x86_64-python-coverage
+          pacman -S --noconfirm mingw64/mingw-w64-x86_64-python-lxml
+          python -m pip install -U pip
           python -m pip install ${{ inputs.requirements }}
 
       - name: ☑ Run unit tests


### PR DESCRIPTION
# New Features
*None*

# Changes
* Split requirements installation into a MSYS2 specific and common step.

# Bug Fixes
* Preinstall Python packages not installed on MSYS2-MinGW64 by default (`wheel`).
* Preinstall packages with binary content (`Coverage`, `lxml`) via Pacman (`pacboy`).
