### PR TITLE
Support with and without isolation mode.

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -66,24 +66,38 @@ jobs:
 
       - name: 🔨 [build] Build Python package (source distribution)
         if: inputs.requirements == ''
-        run: python -m build --no-isolation --sdist
+        run: python -m build --sdist
 
       - name: 🔨 [build] Build Python package (binary distribution - wheel)
         if: inputs.requirements == ''
+        run: python -m build --wheel
+
+      # build (not isolated)
+
+      - name: 🔧 [build] Install dependencies for packaging and release
+        if: inputs.requirements == 'no-isolation'
+        run: python -m pip install build
+
+      - name: 🔨 [build] Build Python package (source distribution)
+        if: inputs.requirements == 'no-isolation'
+        run: python -m build --no-isolation --sdist
+
+      - name: 🔨 [build] Build Python package (binary distribution - wheel)
+        if: inputs.requirements == 'no-isolation'
         run: python -m build --no-isolation --wheel
 
       # setuptools
 
       - name: 🔧 [setuptools] Install dependencies for packaging and release
-        if: inputs.requirements != ''
+        if: inputs.requirements != '' && inputs.requirements != 'no-isolation'
         run: python -m pip install ${{ inputs.requirements }}
 
       - name: 🔨 [setuptools] Build Python package (source distribution)
-        if: inputs.requirements != ''
+        if: inputs.requirements != '' && inputs.requirements != 'no-isolation'
         run: python setup.py sdist
 
       - name: 🔨 [setuptools] Build Python package (binary distribution - wheel)
-        if: inputs.requirements != ''
+        if: inputs.requirements != '' && inputs.requirements != 'no-isolation'
         run: python setup.py bdist_wheel
 
 


### PR DESCRIPTION
# New Features
* Added a 3rd overload for parameter `requirements` in job template `Package`:
  1. When `requirements` is empty  
     &rarr; build Python package with `build` in isolation mode. (old behavior)
  1. When `requirements` is `no-isolation`  
     &rarr; build Python package with `build` in non-isolation mode. (intended behavior since last release, but it had side-effects)
  1. When `requirements` is any other string  
     &rarr; build Python package with `setuptools` using the given `requirements.txt` file to install build dependencies.

# Changes
*None*

# Bug Fixes
* Restore old behavior (run `build` in isolation mode using `venv`).
