### PR TITLE
Split test directory and unit test directory into 2 parameters.

### DIFF
--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -35,10 +35,15 @@ on:
         required: false
         default: '-r tests/requirements.txt'
         type: string
-      unittest_directory:
-        description: 'Path to the directory containing unit tests.'
+      test_directory:
+        description: 'Path to the directory containing tests (test working directory).'
         required: false
-        default: 'tests/unit'
+        default: 'tests'
+        type: string
+      unittest_directory:
+        description: 'Path to the directory containing unit tests (from test_directory).'
+        required: false
+        default: 'unit'
         type: string
       coverage_config:
         description: 'Path to the .coveragerc file. Use pyproject.toml by default.'
@@ -117,6 +122,7 @@ jobs:
       - name: Collect coverage
         continue-on-error: true
         run: |
+          cd ${{ inputs.test_directory }}
           [ 'x${{ inputs.coverage_config }}' != 'x' ] && PYCOV_ARGS='--cov-config=${{ inputs.coverage_config }}' || unset PYCOV_ARGS
           python -m pytest -rA --cov=. $PYCOV_ARGS ${{ inputs.unittest_directory }} --color=yes
 

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -41,7 +41,7 @@ on:
         default: 'tests'
         type: string
       unittest_directory:
-        description: 'Path to the directory containing unit tests (from test_directory).'
+        description: 'Path to the directory containing unit tests (relative to test_directory).'
         required: false
         default: 'unit'
         type: string

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -48,10 +48,15 @@ on:
         required: false
         default: ''
         type: string
-      unittest_directory:
-        description: 'Path to the directory containing unit tests.'
+      test_directory:
+        description: 'Path to the directory containing tests (test working directory).'
         required: false
-        default: 'tests/unit'
+        default: 'tests'
+        type: string
+      unittest_directory:
+        description: 'Path to the directory containing unit tests (from test_directory).'
+        required: false
+        default: 'unit'
         type: string
       artifact:
         description: "Generate unit test report with junitxml and upload results as an artifact."
@@ -113,20 +118,22 @@ jobs:
       - name: ☑ Run unit tests
         if: matrix.system == 'windows'
         run: |
-          $PYTEST_ARGS = if ("${{ inputs.artifact }}".length -gt 0) { "--junitxml=TestReport.xml" } else { "" }
+          cd ${{ inputs.test_directory }}
+          $PYTEST_ARGS = if ("${{ inputs.artifact }}".length -gt 0) { "--junitxml=TestReportSummary.xml" } else { "" }
           python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
 
       - name: ☑ Run unit tests
         if: matrix.system != 'windows'
         run: |
-          [ 'x${{ inputs.artifact }}' != 'x' ] && PYTEST_ARGS='--junitxml=TestReport.xml' || unset PYTEST_ARGS
+          cd ${{ inputs.test_directory }}
+          [ 'x${{ inputs.artifact }}' != 'x' ] && PYTEST_ARGS='--junitxml=TestReportSummary.xml' || unset PYTEST_ARGS
           python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
 
-      - name: 📤 Upload 'TestReport.xml' artifact
+      - name: 📤 Upload 'TestReportSummary.xml' artifact
         if: inputs.artifact != ''
         uses: actions/upload-artifact@v2
         with:
           name: ${{ inputs.artifact }}-${{ matrix.system }}-${{ matrix.python }}
-          path: TestReport.xml
+          path: ${{ inputs.test_directory }}/TestReportSummary.xml
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -48,13 +48,13 @@ on:
         required: false
         default: ''
         type: string
-      test_directory:
+      tests_directory:
         description: 'Path to the directory containing tests (test working directory).'
         required: false
         default: 'tests'
         type: string
       unittest_directory:
-        description: 'Path to the directory containing unit tests (relative to test_directory).'
+        description: 'Path to the directory containing unit tests (relative to tests_directory).'
         required: false
         default: 'unit'
         type: string
@@ -118,14 +118,14 @@ jobs:
       - name: ☑ Run unit tests
         if: matrix.system == 'windows'
         run: |
-          cd ${{ inputs.test_directory }}
+          cd ${{ inputs.tests_directory }}
           $PYTEST_ARGS = if ("${{ inputs.artifact }}".length -gt 0) { "--junitxml=TestReportSummary.xml" } else { "" }
           python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
 
       - name: ☑ Run unit tests
         if: matrix.system != 'windows'
         run: |
-          cd ${{ inputs.test_directory }}
+          cd ${{ inputs.tests_directory }}
           [ 'x${{ inputs.artifact }}' != 'x' ] && PYTEST_ARGS='--junitxml=TestReportSummary.xml' || unset PYTEST_ARGS
           python -m pytest -rA ${{ inputs.unittest_directory }} $PYTEST_ARGS --color=yes
 
@@ -134,6 +134,6 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ inputs.artifact }}-${{ matrix.system }}-${{ matrix.python }}
-          path: ${{ inputs.test_directory }}/TestReportSummary.xml
+          path: ${{ inputs.tests_directory }}/TestReportSummary.xml
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -54,7 +54,7 @@ on:
         default: 'tests'
         type: string
       unittest_directory:
-        description: 'Path to the directory containing unit tests (from test_directory).'
+        description: 'Path to the directory containing unit tests (relative to test_directory).'
         required: false
         default: 'unit'
         type: string

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -52,7 +52,8 @@ jobs:
         python-coverage:p
         python-lxml:p
       mingw_requirements: '-r tests/requirements.mingw.txt'
-      unittest_directory: 'tests/unit'
+      test_directory: 'tests'
+      unittest_directory: 'unit'
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}
 
   Coverage:
@@ -64,6 +65,8 @@ jobs:
       # Optional
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       requirements: '-r tests/requirements.txt'
+      test_directory: 'tests'
+      unittest_directory: 'unit'
     secrets:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
@@ -164,7 +167,16 @@ jobs:
     with:
       package: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
       remaining: |
-        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-*
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.8
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.10
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.8
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.10
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-msys2-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.8
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.10
         ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
         ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
         ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}


### PR DESCRIPTION
```diff
- This is a BREAKING change !
```


# New Features
* Set the working directory of all tests from repository root to the test directory.

# Changes
* Split parameter `unittest_directory` into 2 parameters:
  * `test_directory`
  * `unittest_directory`

# Bug Fixes
* Fixed example pipeline, as wildcards are not supported  
  `${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-*`
