### PR TITLE
Create, Collect, and Publish JUnit Reports from Static Type Checking

### DIFF
--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -28,7 +28,7 @@ on:
       python_version:
         description: 'Python version.'
         required: false
-        default: '3.10'
+        default: '3.11'
         type: string
       requirements:
         description: 'Python dependencies to be installed through pip.'

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -35,13 +35,13 @@ on:
         required: false
         default: '-r tests/requirements.txt'
         type: string
-      test_directory:
+      tests_directory:
         description: 'Path to the directory containing tests (test working directory).'
         required: false
         default: 'tests'
         type: string
       unittest_directory:
-        description: 'Path to the directory containing unit tests (relative to test_directory).'
+        description: 'Path to the directory containing unit tests (relative to tests_directory).'
         required: false
         default: 'unit'
         type: string
@@ -122,16 +122,19 @@ jobs:
       - name: Collect coverage
         continue-on-error: true
         run: |
-          cd ${{ inputs.test_directory }}
-          [ 'x${{ inputs.coverage_config }}' != 'x' ] && PYCOV_ARGS='--cov-config=${{ inputs.coverage_config }}' || unset PYCOV_ARGS
-          python -m pytest -rA --cov=. $PYCOV_ARGS ${{ inputs.unittest_directory }} --color=yes
+          RELDIR="$(realpath --relative-to=${{ inputs.tests_directory }} .)"
+          echo $RELDIR
+          cd ${{ inputs.tests_directory }}
+          [ 'x${{ inputs.coverage_config }}' != 'x' ] && PYCOV_ARGS="--cov-config=$RELDIR/${{ inputs.coverage_config }}" || unset PYCOV_ARGS
+          echo python -m pytest -rA --cov=$RELDIR $PYCOV_ARGS ${{ inputs.unittest_directory }} --color=yes
+          python -m pytest -rA --cov=$RELDIR $PYCOV_ARGS ${{ inputs.unittest_directory }} --color=yes
 
       - name: Convert to cobertura format
-        run: coverage xml
+        run: coverage xml --data-file=${{ inputs.tests_directory }}/.coverage
 
       - name: Convert to HTML format
         run: |
-          coverage html -d ${{ steps.getVariables.outputs.coverage_report_html_directory }}
+          coverage html --data-file=${{ inputs.tests_directory }}/.coverage -d ${{ steps.getVariables.outputs.coverage_report_html_directory }}
           rm ${{ steps.getVariables.outputs.coverage_report_html_directory }}/.gitignore
 
       - name: 📤 Upload 'Coverage Report' artifact

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -28,7 +28,7 @@ on:
       python_version:
         description: 'Python version.'
         required: false
-        default: '3.10'
+        default: '3.11'
         type: string
       requirements:
         description: 'Python dependencies to be installed through pip; if empty, use pyproject.toml through build.'

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -92,11 +92,13 @@ jobs:
           params = {
             'python_version': pythonVersion,
             'artifacts': {
-              'unittesting': f"{name}-TestReport",
-              'coverage':    f"{name}-Coverage",
-              'typing':      f"{name}-Typing",
-              'package':     f"{name}-Package",
-              'doc':         f"{name}-Documentation",
+              'unittesting':   f"{name}-Unittest-Summary",
+              'code-coverage': f"{name}-Code-Coverage",
+              'typing_html':   f"{name}-Typing",
+              'typing_junit':  f"{name}-Typing-Summary",
+              'package':       f"{name}-Package",
+              'doc':           f"{name}-Documentation",
+              'doc-coverage':  f"{name}-Documentation-Coverage",
             }
           }
           print(f"::set-output name=params::{params!s}")

--- a/.github/workflows/PublishOnPyPI.yml
+++ b/.github/workflows/PublishOnPyPI.yml
@@ -28,7 +28,7 @@ on:
       python_version:
         description: 'Python version.'
         required: false
-        default: '3.10'
+        default: '3.11'
         type: string
       requirements:
         description: 'Python dependencies to be installed through pip.'

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -35,18 +35,28 @@ on:
         required: false
         default: '-r tests/requirements.txt'
         type: string
-      report:
-        description: 'Directory to upload as an artifact.'
-        required: false
-        default: 'htmlmypy'
-        type: string
       commands:
         description: 'Commands to run the static type checks.'
         required: true
         type: string
-      artifact:
+      html_report:
+        description: 'Directory to upload as an artifact.'
+        required: false
+        default: 'htmlmypy'
+        type: string
+      junit_report:
+        description: 'junit file to upload as an artifact.'
+        required: false
+        default: 'StaticTypingSummary.xml'
+        type: string
+      html_artifact:
         description: 'Name of the typing artifact.'
         required: true
+        type: string
+      junit_artifact:
+        description: 'Name of the typing artifact.'
+        required: false
+        default: ''
         type: string
 
 jobs:
@@ -73,12 +83,22 @@ jobs:
         continue-on-error: true
         run: ${{ inputs.commands }}
 
-      - name: 📤 Upload 'Static Typing Report' artifact
-        if: ${{ inputs.artifact != '' }}
+      - name: 📤 Upload 'Static Typing Report' HTML artifact
+        if: ${{ inputs.html_artifact != '' }}
         continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ inputs.artifact }}
-          path: ${{ inputs.report }}
+          name: ${{ inputs.html_artifact }}
+          path: ${{ inputs.html_report }}
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: 📤 Upload 'Static Typing Report' JUnit artifact
+        if: ${{ inputs.junit_artifact != '' }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ inputs.junit_artifact }}
+          path: ${{ inputs.junit_report }}
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -28,7 +28,7 @@ on:
       python_version:
         description: 'Python version.'
         required: false
-        default: '3.10'
+        default: '3.11'
         type: string
       requirements:
         description: 'Python dependencies to be installed through pip.'

--- a/.github/workflows/VerifyDocs.yml
+++ b/.github/workflows/VerifyDocs.yml
@@ -28,7 +28,7 @@ on:
       python_version:
         description: 'Python version.'
         required: false
-        default: '3.10'
+        default: '3.11'
         type: string
 
 jobs:

--- a/ExamplePipeline.yml
+++ b/ExamplePipeline.yml
@@ -52,7 +52,7 @@ jobs:
         python-coverage:p
         python-lxml:p
       mingw_requirements: '-r tests/requirements.mingw.txt'
-      test_directory: 'tests'
+      tests_directory: 'tests'
       unittest_directory: 'unit'
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}
 
@@ -65,7 +65,7 @@ jobs:
       # Optional
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       requirements: '-r tests/requirements.txt'
-      test_directory: 'tests'
+      tests_directory: 'tests'
       unittest_directory: 'unit'
     secrets:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
@@ -75,18 +75,22 @@ jobs:
     needs:
       - Params
     with:
-      commands: mypy --html-report htmlmypy -p ToolName
-      artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
+      commands: |
+        mypy --junit-xml StaticTypingSummary.xml --html-report htmlmypy -p ToolName
+      html_artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing_html }}
+      junit_artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.typing_junit }}
       # Optional
       python_version: ${{ fromJson(needs.Params.outputs.params).python_version }}
       requirements: '-r tests/requirements.txt'
-      report: 'htmlmypy'
+      html_report: 'htmlmypy'
+      junit_report: 'StaticTypingSummary.xml'
       allow_failure: true
 
   PublishTestResults:
     uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@main
     needs:
       - UnitTesting
+      - StaticTypeCheck
     with:
       # Optional
       report_files: artifacts/**/*.xml
@@ -178,5 +182,6 @@ jobs:
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.9
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.10
         ${{ fromJson(needs.Params.outputs.params).artifacts.coverage }}
-        ${{ fromJson(needs.Params.outputs.params).artifacts.typing }}
+        ${{ fromJson(needs.Params.outputs.params).artifacts.typing_html }}
+        ${{ fromJson(needs.Params.outputs.params).artifacts.typing_junit }}
         ${{ fromJson(needs.Params.outputs.params).artifacts.doc }}


### PR DESCRIPTION
# New Features
* Create junit summary files from static type checking (`mypy`).
* Collect the junit file as artifact.
* Publish this artifact like other test summary reports.

# Changes
* Renamed `report` and `artifact` in the StaticTyping job template to `html_report` and `html_artifact`.
* Added new `junit_report` and `junit_artifact` parameters.
* Adjusted Parameters job
* Adjusted Example pipeline
* Adjusted artifact cleanup.

# Bug Fixes
*None*

---------------
Related PRs:
* #40 