### PR TITLE
Print 'live' logs from subprocess

### DIFF
--- a/with-post-step/main.js
+++ b/with-post-step/main.js
@@ -26,14 +26,13 @@
  * ================================================================================================================== */
 const { exec } = require("child_process");
 
-function run(cmd) {
-  exec(cmd, (error, stdout, stderr) => {
-    if ( stdout.length !== 0 ) { console.log(`${stdout}`); }
-    if ( stderr.length !== 0 ) { console.error(`${stderr}`); }
-    if (error) {
-      process.exitCode = error.code;
-      console.error(`${error}`);
-    }
+function run(cmdline) {
+  var args = cmdline.split(' ');
+  const cmd = args.shift();
+
+  const subprocess = spawn(cmd, args, { stdio: 'inherit' });
+  subprocess.on('exit', (exit_code) => {
+    process.exitCode = exit_code
   });
 }
 

--- a/with-post-step/main.js
+++ b/with-post-step/main.js
@@ -24,15 +24,15 @@
  * * https://github.com/docker/login-action/issues/72                                                                 *
  * * https://github.com/actions/runner/issues/1478                                                                    *
  * ================================================================================================================== */
-const { exec } = require("child_process");
+const { spawn } = require("child_process");
 
 function run(cmdline) {
-  var args = cmdline.split(' ');
+  var args = cmdline.split(" ");
   const cmd = args.shift();
 
-  const subprocess = spawn(cmd, args, { stdio: 'inherit' });
-  subprocess.on('exit', (exit_code) => {
-    process.exitCode = exit_code
+  const subprocess = spawn(cmd, args, { stdio: "inherit" });
+  subprocess.on("exit", (exitCode) => {
+    process.exitCode = exitCode;
   });
 }
 


### PR DESCRIPTION
# New Features
Print 'live' logs from subprocess

In the basic implementation, logs are printed upon completion of the subprocess, which can be inconvenient in some cases, my solution allows you to print logs "online".

# Changes

Changed `with-post-step/main.js`, to support online logs 

# Bug Fixes
* none

