### PR TITLE
Sort globbed files for releases

### DIFF
--- a/releaser/releaser.py
+++ b/releaser/releaser.py
@@ -70,7 +70,7 @@ def GetListOfArtifacts(argv, files):
         if len(flist) < 1:
             stdout.flush()
             raise (Exception("Empty list of files to upload/update!"))
-        return flist
+        return sorted(flist)
 
 
 def GetGitHubAPIHandler(token):


### PR DESCRIPTION
This change simply sorts the list of files after the glob has been resolved. This is useful because these files are often destined for a release, and having to scroll through hundreds of files which aren't sorted is *painful*.

# New Features
*None*

# Changes
* Sorts files before they're uploaded so that the user sees a nice, sorted list of files on the releases page.

# Bug Fixes
*None*

-----
I'm happy to convert this into an option that can be specified in the yaml if you'd prefer?