### PR TITLE
Upgrade with-post-step action to run using the Node.js 20.x runtime

### DIFF
--- a/with-post-step/action.yml
+++ b/with-post-step/action.yml
@@ -37,6 +37,6 @@ inputs:
     default: POST
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'
   post: 'main.js'


### PR DESCRIPTION
# New Features
 
* tbd

# Changes

* Upgrade with-post-step action to run using the Node.js 20.x runtime

This should address the warning messages below on the GitHub Actions Run Summary Annotations section:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: pyTooling/Actions/with-post-step@v1.0.1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

# Bug Fixes

* tbd

----------
# Related PRs:

* tbd
