### PR TITLE
fix(releaser): fix failure to install PyGithub (#81)

### DIFF
--- a/releaser/composite/action.yml
+++ b/releaser/composite/action.yml
@@ -45,7 +45,7 @@ runs:
   steps:
 
   - shell: bash
-    run: pip install --disable-pip-version-check PyGithub --progress-bar off
+    run: pip install --disable-pip-version-check PyGithub --progress-bar off --break-system-packages
 
   - shell: bash
     run: '''${{ github.action_path }}/../releaser.py'''


### PR DESCRIPTION
This fixes the error message:
× This environment is externally managed (fixes #81).