### PR TITLE
Adding Python 3.13 support

### DIFF
--- a/.btd.yml
+++ b/.btd.yml
@@ -1,9 +1,0 @@
-input: doc
-output: _build
-requirements: requirements.txt
-target: gh-pages
-formats: [ html ]
-images:
-  base: btdi/sphinx:pytooling
-  latex: btdi/latex
-theme: https://codeload.GitHub.com/buildthedocs/sphinx.theme/tar.gz/v1

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -32,12 +32,12 @@ on:
       python_version:
         description: 'Python version.'
         required: false
-        default: '3.12'
+        default: '3.13'
         type: string
       python_version_list:
         description: 'Space separated list of Python versions to run tests with.'
         required: false
-        default: '3.9 3.10 3.11 3.12'
+        default: '3.9 3.10 3.11 3.12 3.13'
         type: string
       system_list:
         description: 'Space separated list of systems to run tests on.'
@@ -123,8 +123,8 @@ jobs:
           disable_list =   "${{ inputs.disable_list }}".strip()
 
           currentMSYS2Version = "3.11"
-          currentAlphaVersion = "3.13"
-          currentAlphaRelease = "3.13.0-alpha.1"
+          currentAlphaVersion = "3.14"
+          currentAlphaRelease = "3.14.0-alpha.1"
 
           if systems == "":
             print("::error title=Parameter::system_list is empty.")
@@ -151,8 +151,8 @@ jobs:
           else:
             disabled = [disable.strip() for disable in disable_list.split(" ")]
 
-          if "3.7" in versions:
-            print("::warning title=Deprecated::Support for Python 3.7 ended in 2023.06.27.")
+          if "3.8" in versions:
+            print("::warning title=Deprecated::Support for Python 3.8 ended in 2024.10.")
           if "msys2" in systems:
             print("::warning title=Deprecated::System 'msys2' will be replaced by 'mingw64'.")
           if currentAlphaVersion in versions:
@@ -164,13 +164,13 @@ jobs:
           data = {
             # Python and PyPy versions supported by "setup-python" action
             "python": {
-              "3.7":       { "icon": "⚫",  "until": "2023.06.27" },
-              "3.8":       { "icon": "🔴",  "until": "2024.10" },
-              "3.9":       { "icon": "🟠",  "until": "2025.10" },
-              "3.10":      { "icon": "🟡",  "until": "2026.10" },
-              "3.11":      { "icon": "🟢",  "until": "2027.10" },
+              "3.8":       { "icon": "⚫",  "until": "2024.10" },
+              "3.9":       { "icon": "🔴",  "until": "2025.10" },
+              "3.10":      { "icon": "🟠",  "until": "2026.10" },
+              "3.11":      { "icon": "🟡",  "until": "2027.10" },
               "3.12":      { "icon": "🟢",  "until": "2028.10" },
-            #  "3.13":      { "icon": "🟣",  "until": "2028.10" },
+              "3.13":      { "icon": "🟢",  "until": "2029.10" },
+              "3.14":      { "icon": "🟣",  "until": "2030.10" },
               "pypy-3.7":  { "icon": "⟲⚫", "until": "????.??" },
               "pypy-3.8":  { "icon": "⟲🔴", "until": "????.??" },
               "pypy-3.9":  { "icon": "⟲🟠", "until": "????.??" },

--- a/.github/workflows/_Checking_ArtifactCleanup.yml
+++ b/.github/workflows/_Checking_ArtifactCleanup.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Params:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@dev
     with:
       name: Example
       python_version_list: "3.12 3.13"

--- a/.github/workflows/_Checking_ArtifactCleanup.yml
+++ b/.github/workflows/_Checking_ArtifactCleanup.yml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   Params:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@r1
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
     with:
       name: Example
-      python_version_list: "3.10 3.11"
+      python_version_list: "3.12 3.13"
       system_list: "ubuntu windows"
 
   Testing:
@@ -50,7 +50,7 @@ jobs:
           retention-days: 1
 
   ArtifactCleanUp:
-    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@r1
+    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@dev
     needs:
       - Params
       - Testing

--- a/.github/workflows/_Checking_Parameters.yml
+++ b/.github/workflows/_Checking_Parameters.yml
@@ -6,54 +6,54 @@ on:
 
 jobs:
   Params_Default:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@r1
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
     with:
       name: Example
 
   Params_PythonVersions:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@r1
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
     with:
       name: Example
-      python_version_list: "3.9 3.10 pypy-3.8 pypy-3.9"
+      python_version_list: "3.11 3.12 pypy-3.9 pypy-3.10"
 
   Params_Systems:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@r1
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
     with:
       name: Example
       system_list: "windows mingw32 mingw64"
 
   Params_Include:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@r1
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
     with:
       name: Example
-      python_version_list: "3.10"
-      system_list: "ubuntu windows macos"
-      include_list: "ubuntu:3.11 ubuntu:3.12"
+      python_version_list: "3.11"
+      system_list: "ubuntu windows macos macos-arm"
+      include_list: "ubuntu:3.12 ubuntu:3.13"
 
   Params_Exclude:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@r1
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
     with:
       name: Example
-      python_version_list: "3.10"
-      system_list: "ubuntu windows macos"
-      exclude_list: "windows:3.10 windows:3.11"
+      python_version_list: "3.12"
+      system_list: "ubuntu windows macos macos-arm"
+      exclude_list: "windows:3.12 windows:3.13"
 
   Params_Disable:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@r1
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
     with:
       name: Example
-      python_version_list: "3.10"
-      system_list: "ubuntu windows macos"
-      disable_list: "windows:3.10 windows:3.11"
+      python_version_list: "3.12"
+      system_list: "ubuntu windows macos macos-arm"
+      disable_list: "windows:3.12 windows:3.13"
 
   Params_All:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@r1
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
     with:
       name: Example
-      python_version_list: "3.10 3.11"
-      system_list: "ubuntu windows macos"
-      include_list: "windows:3.8 windows:3.9 windows:3.12"
-      exclude_list: "macos:3.10 macos:3.11"
+      python_version_list: "3.12 3.13"
+      system_list: "ubuntu windows macos macos-arm"
+      include_list: "windows:3.10 windows:3.11 windows:3.13"
+      exclude_list: "macos:3.12 macos:3.13"
 
   Params_Check:
     needs:
@@ -80,12 +80,10 @@ jobs:
 
           from pyTooling.Common import zipdicts
 
-          expectedPythonVersion = "3.12"
-          expectedPythons = ["3.8", "3.9", "3.10", "3.11", "3.12"]
-          expectedSystems = ["ubuntu", "windows", "macos"]
+          expectedPythonVersion = "3.13"
+          expectedPythons = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+          expectedSystems = ["ubuntu", "windows", "macos", "macos-arm"]
           expectedJobs =    [f"{system}:{python}" for system in expectedSystems for python in expectedPythons] + ["mingw64:3.11", "ucrt64:3.11"]
-          expectedJobs.remove("macos:3.8")
-          expectedJobs.remove("macos:3.9")
           expectedName =    "Example"
           expectedArtifacts = {
             "unittesting_xml":     f"{expectedName}-UnitTestReportSummary-XML",
@@ -116,7 +114,10 @@ jobs:
             print(f"Number of 'python_jobs' does not match: {len(actualPythonJobs)} != {len(expectedJobs)}.")
             print("Actual jobs:")
             for job in actualPythonJobs:
-              print(f"  {job['system']}:{job['python']}")
+              if job['system'] == "msys2":
+                print(f"  {job['runtime'].lower()}:{job['python']}")
+              else:
+                print(f"  {job['system']}:{job['python']}")
             print("Expected jobs:")
             for job in expectedJobs:
               print(f"  {job}")
@@ -142,13 +143,10 @@ jobs:
 
           from pyTooling.Common import zipdicts
 
-          expectedPythonVersion = "3.12"
-          expectedPythons = ["3.9", "3.10", "pypy-3.8", "pypy-3.9"]
-          expectedSystems = ["ubuntu", "windows", "macos"]
+          expectedPythonVersion = "3.13"
+          expectedPythons = ["3.11", "3.12", "pypy-3.9", "pypy-3.10"]
+          expectedSystems = ["ubuntu", "windows", "macos", "macos-arm"]
           expectedJobs =    [f"{system}:{python}" for system in expectedSystems for python in expectedPythons] + ["mingw64:3.11", "ucrt64:3.11"]
-          expectedJobs.remove("macos:3.9")
-          expectedJobs.remove("macos:pypy-3.8")
-          expectedJobs.remove("macos:pypy-3.9")
           expectedName =    "Example"
           expectedArtifacts = {
             "unittesting_xml":     f"{expectedName}-UnitTestReportSummary-XML",
@@ -179,7 +177,10 @@ jobs:
             print(f"Number of 'python_jobs' does not match: {len(actualPythonJobs)} != {len(expectedJobs)}.")
             print("Actual jobs:")
             for job in actualPythonJobs:
-              print(f"  {job['system']}:{job['python']}")
+              if job['system'] == "msys2":
+                print(f"  {job['runtime'].lower()}:{job['python']}")
+              else:
+                print(f"  {job['system']}:{job['python']}")
             print("Expected jobs:")
             for job in expectedJobs:
               print(f"  {job}")
@@ -205,8 +206,8 @@ jobs:
 
           from pyTooling.Common import zipdicts
 
-          expectedPythonVersion = "3.12"
-          expectedPythons = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+          expectedPythonVersion = "3.13"
+          expectedPythons = ["3.9", "3.10", "3.11", "3.12", "3.13"]
           expectedSystems = ["windows"]
           expectedJobs =    [f"{system}:{python}" for system in expectedSystems for python in expectedPythons] + ["mingw32:3.11", "mingw64:3.11"]
           expectedName =    "Example"
@@ -239,7 +240,10 @@ jobs:
             print(f"Number of 'python_jobs' does not match: {len(actualPythonJobs)} != {len(expectedJobs)}.")
             print("Actual jobs:")
             for job in actualPythonJobs:
-              print(f"  {job['system']}:{job['python']}")
+              if job['system'] == "msys2":
+                print(f"  {job['runtime'].lower()}:{job['python']}")
+              else:
+                print(f"  {job['system']}:{job['python']}")
             print("Expected jobs:")
             for job in expectedJobs:
               print(f"  {job}")
@@ -265,9 +269,9 @@ jobs:
 
           from pyTooling.Common import zipdicts
 
-          expectedPythonVersion = "3.12"
-          expectedPythons = ["3.10"]
-          expectedSystems = ["ubuntu", "windows", "macos"]
+          expectedPythonVersion = "3.13"
+          expectedPythons = ["3.12"]
+          expectedSystems = ["ubuntu", "windows", "macos", "macos-arm"]
           expectedJobs =    [f"{system}:{python}" for system in expectedSystems for python in expectedPythons] + ["ubuntu:3.11", "ubuntu:3.12"]
           expectedName =    "Example"
           expectedArtifacts = {
@@ -299,7 +303,10 @@ jobs:
             print(f"Number of 'python_jobs' does not match: {len(actualPythonJobs)} != {len(expectedJobs)}.")
             print("Actual jobs:")
             for job in actualPythonJobs:
-              print(f"  {job['system']}:{job['python']}")
+              if job['system'] == "msys2":
+                print(f"  {job['runtime'].lower()}:{job['python']}")
+              else:
+                print(f"  {job['system']}:{job['python']}")
             print("Expected jobs:")
             for job in expectedJobs:
               print(f"  {job}")
@@ -325,9 +332,9 @@ jobs:
 
           from pyTooling.Common import zipdicts
 
-          expectedPythonVersion = "3.12"
-          expectedPythons = ["3.10"]
-          expectedSystems = ["ubuntu", "macos"]
+          expectedPythonVersion = "3.13"
+          expectedPythons = ["3.12"]
+          expectedSystems = ["ubuntu", "macos", "macos-arm"]
           expectedJobs =    [f"{system}:{python}" for system in expectedSystems for python in expectedPythons]
           expectedName =    "Example"
           expectedArtifacts = {
@@ -359,7 +366,10 @@ jobs:
             print(f"Number of 'python_jobs' does not match: {len(actualPythonJobs)} != {len(expectedJobs)}.")
             print("Actual jobs:")
             for job in actualPythonJobs:
-              print(f"  {job['system']}:{job['python']}")
+              if job['system'] == "msys2":
+                print(f"  {job['runtime'].lower()}:{job['python']}")
+              else:
+                print(f"  {job['system']}:{job['python']}")
             print("Expected jobs:")
             for job in expectedJobs:
               print(f"  {job}")
@@ -385,9 +395,9 @@ jobs:
 
           from pyTooling.Common import zipdicts
 
-          expectedPythonVersion = "3.12"
-          expectedPythons = ["3.10"]
-          expectedSystems = ["ubuntu", "macos"]
+          expectedPythonVersion = "3.13"
+          expectedPythons = ["3.12"]
+          expectedSystems = ["ubuntu", "macos", "macos-arm"]
           expectedJobs =    [f"{system}:{python}" for system in expectedSystems for python in expectedPythons]
           expectedName =    "Example"
           expectedArtifacts = {
@@ -419,7 +429,10 @@ jobs:
             print(f"Number of 'python_jobs' does not match: {len(actualPythonJobs)} != {len(expectedJobs)}.")
             print("Actual jobs:")
             for job in actualPythonJobs:
-              print(f"  {job['system']}:{job['python']}")
+              if job['system'] == "msys2":
+                print(f"  {job['runtime'].lower()}:{job['python']}")
+              else:
+                print(f"  {job['system']}:{job['python']}")
             print("Expected jobs:")
             for job in expectedJobs:
               print(f"  {job}")
@@ -445,10 +458,10 @@ jobs:
 
           from pyTooling.Common import zipdicts
 
-          expectedPythonVersion = "3.12"
-          expectedPythons = ["3.10", "3.11"]
+          expectedPythonVersion = "3.13"
+          expectedPythons = ["3.12", "3.13"]
           expectedSystems = ["ubuntu", "windows"]
-          expectedJobs =    [f"{system}:{python}" for system in expectedSystems for python in expectedPythons] + ["windows:3.8", "windows:3.9", "windows:3.12"]
+          expectedJobs =    [f"{system}:{python}" for system in expectedSystems for python in expectedPythons] + ["windows:3.10", "windows:3.11", "windows:3.13"]
           expectedName =    "Example"
           expectedArtifacts = {
             "unittesting_xml":     f"{expectedName}-UnitTestReportSummary-XML",
@@ -479,7 +492,10 @@ jobs:
             print(f"Number of 'python_jobs' does not match: {len(actualPythonJobs)} != {len(expectedJobs)}.")
             print("Actual jobs:")
             for job in actualPythonJobs:
-              print(f"  {job['system']}:{job['python']}")
+              if job['system'] == "msys2":
+                print(f"  {job['runtime'].lower()}:{job['python']}")
+              else:
+                print(f"  {job['system']}:{job['python']}")
             print("Expected jobs:")
             for job in expectedJobs:
               print(f"  {job}")

--- a/.github/workflows/_Checking_Parameters.yml
+++ b/.github/workflows/_Checking_Parameters.yml
@@ -6,24 +6,24 @@ on:
 
 jobs:
   Params_Default:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@dev
     with:
       name: Example
 
   Params_PythonVersions:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@dev
     with:
       name: Example
       python_version_list: "3.11 3.12 pypy-3.9 pypy-3.10"
 
   Params_Systems:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@dev
     with:
       name: Example
       system_list: "windows mingw32 mingw64"
 
   Params_Include:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@dev
     with:
       name: Example
       python_version_list: "3.11"
@@ -31,7 +31,7 @@ jobs:
       include_list: "ubuntu:3.12 ubuntu:3.13"
 
   Params_Exclude:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@dev
     with:
       name: Example
       python_version_list: "3.12"
@@ -39,7 +39,7 @@ jobs:
       exclude_list: "windows:3.12 windows:3.13"
 
   Params_Disable:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@dev
     with:
       name: Example
       python_version_list: "3.12"
@@ -47,7 +47,7 @@ jobs:
       disable_list: "windows:3.12 windows:3.13"
 
   Params_All:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@dev
     with:
       name: Example
       python_version_list: "3.12 3.13"

--- a/.github/workflows/_Checking_Pipeline.yml
+++ b/.github/workflows/_Checking_Pipeline.yml
@@ -117,11 +117,34 @@ jobs:
     with:
       artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_html }}
 
+  HTMLDocumentation:
+    uses: pyTooling/Actions/.github/workflows/SphinxDocumentation.yml@py313
+    needs:
+      - UnitTestingParams
+#      - VerifyDocs
+    with:
+      python_version: ${{ needs.UnitTestingParams.outputs.python_version }}
+#      unittest_xml_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}
+#      coverage_json_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_json }}
+      html_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_html }}
+      latex_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_latex }}
+
+  PDFDocumentation:
+    uses: pyTooling/Actions/.github/workflows/LaTeXDocumentation.yml@r1
+    needs:
+      - UnitTestingParams
+      - HTMLDocumentation
+    with:
+      document: actions
+      latex_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_latex }}
+      pdf_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_pdf }}
+
   PublishToGitHubPages:
     uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@py313
     needs:
       - UnitTestingParams
-      - BuildTheDocs
+      - HTMLDocumentation
+      - PDFDocumentation
 #      - Coverage
       - PublishCoverageResults
       - StaticTypeCheck

--- a/.github/workflows/_Checking_Pipeline.yml
+++ b/.github/workflows/_Checking_Pipeline.yml
@@ -6,21 +6,21 @@ on:
 
 jobs:
   UnitTestingParams:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@dev
     with:
       name: pyDummy
       python_version_list: "3.8 3.9 3.10 3.11 3.12 3.13 pypy-3.8 pypy-3.9 pypy-3.10"
 #      disable_list: "windows:pypy-3.10"
 
   PlatformTestingParams:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@dev
     with:
       name: Platform
       python_version_list: ""
       system_list: "ubuntu windows macos mingw32 mingw64 clang64 ucrt64"
 
   UnitTesting:
-    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@py313
+    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev
     needs:
       - UnitTestingParams
     with:
@@ -33,7 +33,7 @@ jobs:
 #      coverage_html_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_html }}
 
   PlatformTesting:
-    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@py313
+    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev
     needs:
       - PlatformTestingParams
     with:
@@ -48,7 +48,7 @@ jobs:
       coverage_html_artifact: ${{ fromJson(needs.PlatformTestingParams.outputs.artifact_names).codecoverage_html }}
 
 #  Coverage:
-#    uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@py313
+#    uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@dev
 #    needs:
 #      - UnitTestingParams
 #    with:
@@ -58,7 +58,7 @@ jobs:
 #      codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   StaticTypeCheck:
-    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@py313
+    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@dev
     needs:
       - UnitTestingParams
     with:
@@ -69,7 +69,7 @@ jobs:
       html_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).statictyping_html }}
 
   PublishCoverageResults:
-    uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@py313
+    uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@dev
     needs:
       - UnitTestingParams
       - UnitTesting
@@ -84,7 +84,7 @@ jobs:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   PublishTestResults:
-    uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@py313
+    uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@dev
     needs:
       - UnitTesting
       - PlatformTesting
@@ -92,7 +92,7 @@ jobs:
       additional_merge_args: '-d "--pytest=rewrite-dunder-init;reduce-depth:pytest.tests.unit;reduce-depth:pytest.tests.platform"'
 
   Package:
-    uses: pyTooling/Actions/.github/workflows/Package.yml@py313
+    uses: pyTooling/Actions/.github/workflows/Package.yml@dev
     needs:
       - UnitTestingParams
       - UnitTesting
@@ -103,14 +103,14 @@ jobs:
       artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).package_all }}
 
 #  VerifyDocs:
-#    uses: pyTooling/Actions/.github/workflows/VerifyDocs.yml@py313
+#    uses: pyTooling/Actions/.github/workflows/VerifyDocs.yml@dev
 #    needs:
 #      - UnitTestingParams
 #    with:
 #      python_version: ${{ needs.UnitTestingParams.outputs.python_version }}
 
   HTMLDocumentation:
-    uses: pyTooling/Actions/.github/workflows/SphinxDocumentation.yml@py313
+    uses: pyTooling/Actions/.github/workflows/SphinxDocumentation.yml@dev
     needs:
       - UnitTestingParams
 #      - VerifyDocs
@@ -132,7 +132,7 @@ jobs:
       pdf_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_pdf }}
 
   PublishToGitHubPages:
-    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@py313
+    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@dev
     needs:
       - UnitTestingParams
       - HTMLDocumentation
@@ -146,7 +146,7 @@ jobs:
       typing: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).statictyping_html }}
 
   ReleasePage:
-    uses: pyTooling/Actions/.github/workflows/Release.yml@py313
+    uses: pyTooling/Actions/.github/workflows/Release.yml@dev
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - UnitTesting
@@ -157,7 +157,7 @@ jobs:
       - PublishToGitHubPages
 
   PublishOnPyPI:
-    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@py313
+    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@dev
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - UnitTestingParams
@@ -171,7 +171,7 @@ jobs:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
   ArtifactCleanUp:
-    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@py313
+    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@dev
     needs:
       - UnitTestingParams
       - PlatformTestingParams

--- a/.github/workflows/_Checking_Pipeline.yml
+++ b/.github/workflows/_Checking_Pipeline.yml
@@ -6,21 +6,21 @@ on:
 
 jobs:
   UnitTestingParams:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@r1
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
     with:
       name: pyDummy
-      python_version_list: "3.8 3.9 3.10 3.11 3.12 pypy-3.8 pypy-3.9 pypy-3.10"
-      disable_list: "windows:pypy-3.10"
+      python_version_list: "3.8 3.9 3.10 3.11 3.12 3.13 pypy-3.8 pypy-3.9 pypy-3.10"
+#      disable_list: "windows:pypy-3.10"
 
   PlatformTestingParams:
-    uses: pyTooling/Actions/.github/workflows/Parameters.yml@r1
+    uses: pyTooling/Actions/.github/workflows/Parameters.yml@py313
     with:
       name: Platform
       python_version_list: ""
       system_list: "ubuntu windows macos mingw32 mingw64 clang64 ucrt64"
 
   UnitTesting:
-    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@r1
+    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@py313
     needs:
       - UnitTestingParams
     with:
@@ -33,7 +33,7 @@ jobs:
 #      coverage_html_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_html }}
 
   PlatformTesting:
-    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@r1
+    uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@py313
     needs:
       - PlatformTestingParams
     with:
@@ -48,7 +48,7 @@ jobs:
       coverage_html_artifact: ${{ fromJson(needs.PlatformTestingParams.outputs.artifact_names).codecoverage_html }}
 
 #  Coverage:
-#    uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@r1
+#    uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@py313
 #    needs:
 #      - UnitTestingParams
 #    with:
@@ -58,7 +58,7 @@ jobs:
 #      codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   StaticTypeCheck:
-    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@r1
+    uses: pyTooling/Actions/.github/workflows/StaticTypeCheck.yml@py313
     needs:
       - UnitTestingParams
     with:
@@ -69,7 +69,7 @@ jobs:
       html_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).statictyping_html }}
 
   PublishCoverageResults:
-    uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@r1
+    uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@py313
     needs:
       - UnitTestingParams
       - UnitTesting
@@ -84,7 +84,7 @@ jobs:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   PublishTestResults:
-    uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@dev
+    uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@py313
     needs:
       - UnitTesting
       - PlatformTesting
@@ -92,7 +92,7 @@ jobs:
       additional_merge_args: '-d "--pytest=rewrite-dunder-init;reduce-depth:pytest.tests.unit;reduce-depth:pytest.tests.platform"'
 
   Package:
-    uses: pyTooling/Actions/.github/workflows/Package.yml@r1
+    uses: pyTooling/Actions/.github/workflows/Package.yml@py313
     needs:
       - UnitTestingParams
       - UnitTesting
@@ -103,14 +103,14 @@ jobs:
       artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).package_all }}
 
 #  VerifyDocs:
-#    uses: pyTooling/Actions/.github/workflows/VerifyDocs.yml@r1
+#    uses: pyTooling/Actions/.github/workflows/VerifyDocs.yml@py313
 #    needs:
 #      - UnitTestingParams
 #    with:
 #      python_version: ${{ needs.UnitTestingParams.outputs.python_version }}
 
   BuildTheDocs:
-    uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@r1
+    uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@py313
     needs:
       - UnitTestingParams
 #      - VerifyDocs
@@ -118,7 +118,7 @@ jobs:
       artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_html }}
 
   PublishToGitHubPages:
-    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@r1
+    uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@py313
     needs:
       - UnitTestingParams
       - BuildTheDocs
@@ -131,7 +131,7 @@ jobs:
       typing: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).statictyping_html }}
 
   ReleasePage:
-    uses: pyTooling/Actions/.github/workflows/Release.yml@r1
+    uses: pyTooling/Actions/.github/workflows/Release.yml@py313
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - UnitTesting
@@ -142,7 +142,7 @@ jobs:
       - PublishToGitHubPages
 
   PublishOnPyPI:
-    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@r1
+    uses: pyTooling/Actions/.github/workflows/PublishOnPyPI.yml@py313
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - UnitTestingParams
@@ -156,7 +156,7 @@ jobs:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
   ArtifactCleanUp:
-    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@r1
+    uses: pyTooling/Actions/.github/workflows/ArtifactCleanUp.yml@py313
     needs:
       - UnitTestingParams
       - PlatformTestingParams

--- a/.github/workflows/_Checking_Pipeline.yml
+++ b/.github/workflows/_Checking_Pipeline.yml
@@ -109,14 +109,6 @@ jobs:
 #    with:
 #      python_version: ${{ needs.UnitTestingParams.outputs.python_version }}
 
-  BuildTheDocs:
-    uses: pyTooling/Actions/.github/workflows/BuildTheDocs.yml@py313
-    needs:
-      - UnitTestingParams
-#      - VerifyDocs
-    with:
-      artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_html }}
-
   HTMLDocumentation:
     uses: pyTooling/Actions/.github/workflows/SphinxDocumentation.yml@py313
     needs:
@@ -144,7 +136,7 @@ jobs:
     needs:
       - UnitTestingParams
       - HTMLDocumentation
-      - PDFDocumentation
+#      - PDFDocumentation
 #      - Coverage
       - PublishCoverageResults
       - StaticTypeCheck

--- a/doc/JobTemplate/Parameters.rst
+++ b/doc/JobTemplate/Parameters.rst
@@ -138,7 +138,7 @@ python_version_list
 | Parameter Name       | Required | Type     | Default                    |
 +======================+==========+==========+============================+
 | python_version_list  | optional | string   | ``3.8 3.9 3.10 3.11 3.12`` |
-+----------------------+----------+----------+-------------------------- -+
++----------------------+----------+----------+----------------------------+
 
 Space separated list of CPython versions and/or mypy version to run tests with.
 

--- a/doc/_static/css/override.css
+++ b/doc/_static/css/override.css
@@ -1,0 +1,115 @@
+/* theme overrides */
+.rst-content h1,
+.rst-content h2 {
+	margin-top: 24px;
+	margin-bottom: 6px;
+	text-decoration: underline;
+}
+
+.rst-content h3,
+.rst-content h4,
+.rst-content h5,
+.rst-content h6 {
+	margin-top: 12px;
+	margin-bottom: 6px;
+}
+
+.rst-content p {
+	margin-bottom: 6px
+}
+
+/* general overrides */
+html {
+	font-size: 15px;
+}
+
+footer {
+  font-size: 95%;
+  text-align: center
+}
+
+footer p {
+  margin-bottom: 0px /* 12px */;
+  font-size: 95%
+}
+
+section > p,
+.section p,
+.simple li {
+	text-align: justify
+}
+
+.rst-content .topic-title {
+	font-size: larger;
+	font-weight: 700;
+	margin-top: 18px;
+	margin-bottom: 6px;
+}
+
+.rst-content p.rubric {
+	text-decoration: underline;
+	font-weight: 700;
+	margin-top: 18px;
+	margin-bottom: 16px;
+}
+
+/* wyrm overrides */
+.wy-menu-vertical header,
+.wy-menu-vertical p.caption {
+	color: #9b9b9b /* #55a5d9 */;
+	padding: 0 0.809em /* 0 1.618em */;
+	margin: 6px 0 0 0 /* 12px 0 0 */;
+	border-top: 1px solid #9b9b9b;
+}
+
+.wy-side-nav-search {
+	margin-bottom: 0 /* .809em */;
+	background-color: #333333 /* #2980b9 */;
+	/* BTD: */
+	/*color: #fcfcfc*/
+}
+
+.wy-side-nav-search input[type=text] {
+	border-radius: 0px /* 50px */;
+}
+
+.wy-side-nav-search .wy-dropdown > a, .wy-side-nav-search > a {
+	/* BTD: */
+	/*color: #fcfcfc;*/
+	margin-bottom: 0.404em /* .809em */;
+}
+
+.wy-side-nav-search > div.version {
+  margin: 0 0 6px 0;
+  /* BTD: */
+  /*margin-top: -.4045em;*/
+}
+
+.wy-nav .wy-menu-vertical a:hover {
+  background-color:  #333333 /* #2980b9 */;
+}
+
+.wy-nav-content {
+  max-width: 1600px /* 800px */ ;
+}
+
+.wy-nav-top {
+  background:  #333333 /* #2980b9 */;
+}
+
+/* Sphinx Design */
+.sd-tab-set {
+	margin: 0
+}
+
+.sd-tab-set > label {
+	padding-top: .5em;
+	padding-right: 1em;
+	padding-bottom: .5em;
+	padding-left: 1em
+}
+
+.sd-container-fluid {
+	padding-left: 0;
+	padding-right: 0;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -186,7 +186,6 @@ extensions = [
 # SphinxContrib extensions
 	"sphinxcontrib.mermaid",
 # Other extensions
-	"sphinx_fontawesome",
 	"sphinx_autodoc_typehints",
 	"sphinx_inline_tabs",
 	"autoapi.sphinx",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,7 +14,7 @@ ROOT = Path(__file__).resolve().parent
 sys_path.insert(0, abspath("."))
 sys_path.insert(0, abspath(".."))
 sys_path.insert(0, abspath("../pyDummy"))
-sys_path.insert(0, abspath("_extensions"))
+# sys_path.insert(0, abspath("_extensions"))
 
 
 # ==============================================================================
@@ -23,9 +23,11 @@ sys_path.insert(0, abspath("_extensions"))
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-project = "Actions"
+githubNamespace = "pyTooling"
+githubProject = "Actions"
+project = "pyDummy"
 
-packageInformationFile = Path(f"../pyDummy/__init__.py")
+packageInformationFile = Path(f"../{project}/__init__.py")
 versionInformation = extractVersionInformation(packageInformationFile)
 
 author =    versionInformation.Author
@@ -73,30 +75,15 @@ except Exception as ex:
 # ==============================================================================
 # Options for HTML output
 # ==============================================================================
-html_context = {}
-ctx = ROOT / "context.json"
-if ctx.is_file():
-	html_context.update(loads(ctx.open('r').read()))
-
-if (ROOT / "_theme").is_dir():
-	html_theme_path = ["."]
-	html_theme = "_theme"
-	html_theme_options = {
-		"logo_only": True,
-		"home_breadcrumbs": False,
-		"vcs_pageview_mode": 'blob',
-#		"body_max_width": None
-#		"navigation_depth": 5,
-	}
-elif find_spec("sphinx_rtd_theme") is not None:
-	html_theme = "sphinx_rtd_theme"
-	html_theme_options = {
-		"logo_only": True,
-		"vcs_pageview_mode": 'blob',
-#		"navigation_depth": 5,
-	}
-else:
-	html_theme = "alabaster"
+html_theme = "sphinx_rtd_theme"
+html_theme_options = {
+	"logo_only": True,
+	"vcs_pageview_mode": 'blob',
+	"navigation_depth": 5,
+}
+html_css_files = [
+	'css/override.css',
+]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -107,7 +94,7 @@ html_logo = str(Path(html_static_path[0]) / "logo.png")
 html_favicon = str(Path(html_static_path[0]) / "icon.png")
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = "ActionsDoc"
+htmlhelp_basename = f"{githubProject}Doc"
 
 # If not None, a 'Last updated on:' timestamp is inserted at every page
 # bottom, using the given strftime format.
@@ -160,10 +147,10 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
 	( master_doc,
-		"Actions.tex",
-		"The pyTooling Actions Documentation",
-		"Patrick Lehmann",
-		"manual"
+		f"{githubProject}.tex",
+		f"The {githubProject} Documentation",
+		f"Patrick Lehmann",
+		f"manual"
 	),
 ]
 
@@ -174,7 +161,6 @@ latex_documents = [
 extensions = [
 # Standard Sphinx extensions
 	"sphinx.ext.autodoc",
-	"sphinx.ext.coverage",
 	"sphinx.ext.extlinks",
 	"sphinx.ext.intersphinx",
 	"sphinx.ext.inheritance_diagram",
@@ -186,9 +172,12 @@ extensions = [
 # SphinxContrib extensions
 	"sphinxcontrib.mermaid",
 # Other extensions
+	"sphinx_design",
+	"sphinx_copybutton",
 	"sphinx_autodoc_typehints",
-	"sphinx_inline_tabs",
 	"autoapi.sphinx",
+	"sphinx_reports",
+# User defined extensions
 ]
 
 
@@ -220,11 +209,11 @@ autodoc_typehints = "both"
 # Sphinx.Ext.ExtLinks
 # ==============================================================================
 extlinks = {
-	"gh":      ("https://GitHub.com/%s", "gh:%s"),
- 	"ghissue": ("https://GitHub.com/pyTooling/Actions/issues/%s", "issue #%s"),
- 	"ghpull":  ("https://GitHub.com/pyTooling/Actions/pull/%s", "pull request #%s"),
- 	"ghsrc":   ("https://GitHub.com/pyTooling/Actions/blob/main/%s", None),
- 	"wiki":    ("https://en.wikipedia.org/wiki/%s", None),
+	"gh":      (f"https://GitHub.com/%s", "gh:%s"),
+	"ghissue": (f"https://GitHub.com/{githubNamespace}/{githubProject}/issues/%s", "issue #%s"),
+	"ghpull":  (f"https://GitHub.com/{githubNamespace}/{githubProject}/pull/%s", "pull request #%s"),
+	"ghsrc":   (f"https://GitHub.com/{githubNamespace}/{githubProject}/blob/main/%s", None),
+	"wiki":    (f"https://en.wikipedia.org/wiki/%s", None),
 }
 
 
@@ -264,18 +253,53 @@ todo_link_only = True
 
 
 # ==============================================================================
-# Sphinx.Ext.Coverage
+# sphinx-reports
 # ==============================================================================
-coverage_show_missing_items = True
+# report_unittest_testsuites = {
+# 	"src": {
+# 		"name":        f"{project}",
+# 		"xml_report":  "../report/unit/unittest.xml",
+# 	}
+# }
+# report_codecov_packages = {
+# 	"src": {
+# 		"name":        f"{project}",
+# 		"json_report": "../report/coverage/coverage.json",
+# 		"fail_below":  80,
+# 		"levels":      "default"
+# 	}
+# }
+# report_doccov_packages = {
+# 	"src": {
+# 		"name":       f"{project}",
+# 		"directory":  f"../{project}",
+# 		"fail_below": 80,
+# 		"levels":     "default"
+# 	}
+# }
+
+
+# ==============================================================================
+# Sphinx_Design
+# ==============================================================================
+# sd_fontawesome_latex = True
 
 
 # ==============================================================================
 # AutoAPI.Sphinx
 # ==============================================================================
 autoapi_modules = {
-	"pyDummy":  {
-		"template": "module",
-		"output": "pyDummy",
+	f"{project}":  {
+		"template": "package",
+		"output":   project,
 		"override": True
 	}
 }
+
+for directory in [mod for mod in Path(f"../{project}").iterdir() if mod.is_dir() and mod.name != "__pycache__"]:
+	print(f"Adding module rule for '{project}.{directory.name}'")
+	autoapi_modules[f"{project}.{directory.name}"] = {
+		"template": "module",
+		"output":   project,
+		"override": True
+	}

--- a/doc/coverage/index.rst
+++ b/doc/coverage/index.rst
@@ -3,5 +3,5 @@ Code Coverage Report
 
 Code coverage report generated with `pytest <https://github.com/pytest-dev/pytest>`__ and `Coverage.py <https://github.com/nedbat/coveragepy/tree/master>`__.
 
-.. report:code-coverage::
+.. #report:code-coverage::
    :packageid: src

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,6 +6,9 @@ pyTooling ~= 6.7
 sphinx ~= 8.1
 docutils ~= 0.21
 
+# ReadTheDocs Theme
+sphinx_rtd_theme ~= 3.0
+
 # Sphinx Extenstions
 #sphinx.ext.coverage
 #sphinxcontrib-actdiag>=0.8.5
@@ -18,3 +21,6 @@ sphinx_design ~= 0.6.1
 sphinx-copybutton >= 0.5.2
 sphinx_autodoc_typehints ~= 2.5
 # changelog>=0.3.5
+sphinx_reports ~= 0.6
+
+# BuildTheDocs Extensions (mostly patched Sphinx extensions)

--- a/doc/shields.inc
+++ b/doc/shields.inc
@@ -7,11 +7,11 @@
 .. |SHIELD:svg:pyTooling-github| image:: https://img.shields.io/badge/pyTooling-Actions-63bf7f.svg?longCache=true&style=flat-square&longCache=true&logo=GitHub
    :alt: Sourcecode on GitHub
    :height: 22
-   :target: https://GitHub.com/pyTooling/pyTooling
+   :target: https://GitHub.com/pyTooling/Actions
 .. |SHIELD:png:pyTooling-github| image:: https://raster.shields.io/badge/pyTooling-Actions-63bf7f.svg?longCache=true&style=flat-square&longCache=true&logo=GitHub
    :alt: Sourcecode on GitHub
    :height: 22
-   :target: https://GitHub.com/pyTooling/pyTooling
+   :target: https://GitHub.com/pyTooling/Actions
 
 .. # Sourcecode license
 .. |SHIELD:svg:pyTooling-src-license| image:: https://img.shields.io/pypi/l/pyTooling?longCache=true&style=flat-square&logo=Apache&label=code

--- a/doc/unittests/index.rst
+++ b/doc/unittests/index.rst
@@ -3,5 +3,5 @@ Unittest Summary Report
 
 Unittest report generated with `pytest <https://github.com/pytest-dev/pytest>`__.
 
-.. report:unittest-summary::
+.. #report:unittest-summary::
    :reportid: src


### PR DESCRIPTION
# New Features

* Added Python 3.13 support
* Enabled Python 3.14 (alpha) support

# Changes

* made Python 3.13 the default Python version.
* Removed Python 3.7.
* Marked Python 3.8 in black (outdated).

# Bug Fixes

*None*

# Documentation

* Switched from BuildTheDocs to standard Sphinx build flow.
  * Updated `conf.py`.
  * Added `override.css`.
* Fixed some links.

# Unit Tests

* Updated parameter checks.
* Added checks for `macos-arm`.
