### PR TITLE
Backport of v3.1.0.

### DIFF
--- a/.github/workflows/NightlyRelease.yml
+++ b/.github/workflows/NightlyRelease.yml
@@ -68,6 +68,10 @@ on:
         description: 'Multi-line string containing artifact:file:title asset descriptions.'
         required: true
         type: string
+      tarball-name:
+        type: string
+        required: false
+        default: '__pyTooling_upload_artifact__.tar'
 
 jobs:
   Release:
@@ -251,6 +255,25 @@ jobs:
                 continue
               fi
               downloadedArtifacts[$artifact]=1
+
+              echo -n "  Checking for embedded tarball ... "
+              if [[ -f "${artifact}/${{ inputs.tarball-name }}" ]]; then
+                echo -e "${ANSI_LIGHT_GREEN}[FOUND]${ANSI_NOCOLOR}"
+
+                pushd "${artifact}" > /dev/null
+
+                echo -n "    Extracting embedded tarball ... "
+                tar -xf "${{ inputs.tarball-name }}"
+                if [[ $? -ne 0 ]]; then
+                  echo -e "${ANSI_LIGHT_RED}[FAILED]${ANSI_NOCOLOR}"
+                else
+                  echo -e "${ANSI_LIGHT_GREEN}[OK]${ANSI_NOCOLOR}"
+                fi
+
+                popd > /dev/null
+              else
+                echo -e "${ANSI_LIGHT_YELLOW}[SKIPPED]${ANSI_NOCOLOR}"
+              fi
             fi
 
             # Check if artifact should be compressed (zip, tgz) or if asset was part of the downloaded artifact.

--- a/.github/workflows/_Checking_Nightly.yml
+++ b/.github/workflows/_Checking_Nightly.yml
@@ -32,7 +32,7 @@ jobs:
           echo "Program $(date --utc '+%d.%m.%Y - %H:%M:%S')"        > program.py
 
       - name: 📤 Upload artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: other
           path: |


### PR DESCRIPTION
Backport of [v3.1.0](https://github.com/pyTooling/Actions/pull/99).

# New Features

Support embedded tarballs for nightly release's artifacts when uploaded via pyTooling/upload-artifact.

# Unit Tests

Check nightly release's artifact downloader with/without embedded tarball.