### PR TITLE
v4.2.2

### DIFF
--- a/.github/workflows/SphinxDocumentation.yml
+++ b/.github/workflows/SphinxDocumentation.yml
@@ -183,8 +183,8 @@ jobs:
       - name: Workaround I - https://github.com/sphinx-doc/sphinx/issues/13190
         if: inputs.latex_artifact != ''
         run: |
-          printf "Changing directory to 'doc/_build/latex' ...\n"
-          cd doc/_build/latex
+          printf "Changing directory to '${{ inputs.doc_directory || '.' }}/_build/latex' ...\n"
+          cd ${{ inputs.doc_directory || '.' }}/_build/latex
 
           MIMETYPE_EXTENSIONS=(
             "image/png:png"
@@ -232,8 +232,8 @@ jobs:
       - name: Workaround II - https://github.com/sphinx-doc/sphinx/issues/13189
         if: inputs.latex_artifact != ''
         run: |
-          printf "Changing directory to 'doc/_build/latex' ...\n"
-          cd doc/_build/latex
+          printf "Changing directory to '${{ inputs.doc_directory || '.' }}/_build/latex' ...\n"
+          cd ${{ inputs.doc_directory || '.' }}/_build/latex
 
           printf "Searching for downloaded images, that need normalization ...\n"
           for imageExt in png svg jpg jpeg; do

--- a/.github/workflows/SphinxDocumentation.yml
+++ b/.github/workflows/SphinxDocumentation.yml
@@ -46,7 +46,7 @@ on:
         type: string
       coverage_report_json_directory:
         description: ''
-        required: true
+        required: false
         type: string
       coverage_json_artifact:
         description: 'Name of the coverage JSON artifact.'


### PR DESCRIPTION
# Bug Fixes

* Do not require `coverage_report_json_directory` in `SphinxDocumentation.yml`.
* Use `doc_directory` instead of hard-coded paths for workarounds.


----------
# Related Issues and Pull-Requests

* Fixes #118
* Fixes #119
