### PR TITLE
v4.3.0

### DIFF
--- a/.github/workflows/CheckDocumentation.yml
+++ b/.github/workflows/CheckDocumentation.yml
@@ -32,7 +32,7 @@ on:
       python_version:
         description: 'Python version.'
         required: false
-        default: '3.12'
+        default: '3.13'
         type: string
       directory:
         description: 'Source code directory to check.'

--- a/.github/workflows/CompletePipeline.yml
+++ b/.github/workflows/CompletePipeline.yml
@@ -206,10 +206,12 @@ jobs:
   PublishTestResults:
     uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@dev
     needs:
+      - ConfigParams
       - UnitTestingParams
       - UnitTesting
     with:
       additional_merge_args: '-d "--pytest=rewrite-dunder-init;reduce-depth:pytest.tests.unit"'
+      merged_junit_filename: ${{ needs.ConfigParams.outputs.unittest_merged_report_xml_filename }}
       merged_junit_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}
 
 #  VerifyDocs:

--- a/.github/workflows/CompletePipeline.yml
+++ b/.github/workflows/CompletePipeline.yml
@@ -172,7 +172,7 @@ jobs:
       - UnitTestingParams
     with:
       python_version: ${{ needs.UnitTestingParams.outputs.python_version }}
-      directory: ${{ inputs.package_namespace }}/${{ inputs.package_name }}
+      directory:      ${{ inputs.package_namespace }}/${{ inputs.package_name }}
 #      fail_below: 70
 
   Package:
@@ -182,7 +182,7 @@ jobs:
       - UnitTesting
     with:
       python_version: ${{ needs.UnitTestingParams.outputs.python_version }}
-      artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).package_all }}
+      artifact:       ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).package_all }}
 
 #  AppTesting:
 #    uses: pyTooling/Actions/.github/workflows/ApplicationTesting.yml@dev
@@ -198,13 +198,20 @@ jobs:
   PublishCoverageResults:
     uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@dev
     needs:
+      - ConfigParams
       - UnitTestingParams
       - UnitTesting
     with:
-#      coverage_sqlite_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_sqlite }}
-#      coverage_xml_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_xml }}
-      coverage_json_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_json }}
-      coverage_html_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_html }}
+#      coverage_sqlite_artifact:       ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_sqlite }}
+#      coverage_xml_artifact:          ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_xml }}
+#      coverage_report_xml_directory:  ${{ needs.ConfigParams.outputs.coverage_report_xml_directory }}
+#      coverage_report_xml_filename:   ${{ needs.ConfigParams.outputs.coverage_report_xml_filename }}
+      coverage_json_artifact:         ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_json }}
+      coverage_report_json_directory: ${{ needs.ConfigParams.outputs.coverage_report_json_directory }}
+      coverage_report_json_filename:  ${{ needs.ConfigParams.outputs.coverage_report_json_filename }}
+      coverage_html_artifact:         ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_html }}
+      coverage_report_html_directory: ${{ needs.ConfigParams.outputs.coverage_report_html_directory }}
+
     secrets:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
@@ -235,12 +242,12 @@ jobs:
       - PublishCoverageResults
 #      - VerifyDocs
     with:
-      python_version: ${{ needs.UnitTestingParams.outputs.python_version }}
+      python_version:                 ${{ needs.UnitTestingParams.outputs.python_version }}
       coverage_report_json_directory: ${{ needs.ConfigParams.outputs.coverage_report_json_directory }}
-      unittest_xml_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}
-      coverage_json_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_json }}
-      html_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_html }}
-      latex_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_latex }}
+      unittest_xml_artifact:          ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}
+      coverage_json_artifact:         ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_json }}
+      html_artifact:                  ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_html }}
+      latex_artifact:                 ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_latex }}
 
   IntermediateCleanUp:
     uses: pyTooling/Actions/.github/workflows/IntermediateCleanUp.yml@dev
@@ -252,7 +259,7 @@ jobs:
     if: ${{ inputs.cleanup }}
     with:
       sqlite_coverage_artifacts_prefix: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_sqlite }}-
-      xml_unittest_artifacts_prefix: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}-
+      xml_unittest_artifacts_prefix:    ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}-
 
 #  PDFDocumentation:
 #    uses: pyTooling/Actions/.github/workflows/LaTeXDocumentation.yml@dev
@@ -273,9 +280,9 @@ jobs:
       - PublishCoverageResults
       - StaticTypeCheck
     with:
-      doc: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_html }}
+      doc:      ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_html }}
       coverage: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_html }}
-      typing: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).statictyping_html }}
+      typing:   ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).statictyping_html }}
 
   ReleasePage:
     uses: pyTooling/Actions/.github/workflows/Release.yml@dev

--- a/.github/workflows/CompletePipeline.yml
+++ b/.github/workflows/CompletePipeline.yml
@@ -230,7 +230,7 @@ jobs:
     with:
       python_version: ${{ needs.UnitTestingParams.outputs.python_version }}
       coverage_report_json_directory: ${{ needs.ConfigParams.outputs.coverage_report_json_directory }}
-      unittest_xml_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}-ubuntu-native-3.12
+      unittest_xml_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}
       coverage_json_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_json }}
       html_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_html }}
       latex_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_latex }}

--- a/.github/workflows/CompletePipeline.yml
+++ b/.github/workflows/CompletePipeline.yml
@@ -93,6 +93,11 @@ on:
         required: false
         default: ''
         type: string
+      cleanup:
+        description: 'Cleanup artifacts afterwards.'
+        required: false
+        default: true
+        type: boolean
     secrets:
       PYPI_TOKEN:
         description: "Token for pushing releases to PyPI."
@@ -244,6 +249,7 @@ jobs:
       - PublishCoverageResults
       - PublishTestResults
       - Documentation
+    if: ${{ inputs.cleanup }}
     with:
       sqlite_coverage_artifacts_prefix: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_sqlite }}-
       xml_unittest_artifacts_prefix: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}-
@@ -305,6 +311,7 @@ jobs:
       - PublishToGitHubPages
 #      - PublishOnPyPI
       - IntermediateCleanUp
+    if: ${{ inputs.cleanup }}
     with:
       package: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).package_all }}
       remaining: |

--- a/.github/workflows/CompletePipeline.yml
+++ b/.github/workflows/CompletePipeline.yml
@@ -102,6 +102,9 @@ on:
       PYPI_TOKEN:
         description: "Token for pushing releases to PyPI."
         required: false
+      CODECOV_TOKEN:
+        description: "Token for pushing coverage and unittest results to Codecov."
+        required: false
       CODACY_PROJECT_TOKEN:
         description: "Token for pushing coverage results to Codacy."
         required: false
@@ -132,10 +135,10 @@ jobs:
       package_name:        ${{ inputs.package_name }}
       python_version:      ${{ inputs.apptest_python_version }}
       python_version_list: ${{ inputs.apptest_python_version_list }}
-      system_list:  ${{ inputs.apptest_system_list }}
-      include_list: ${{ inputs.apptest_include_list }}
-      exclude_list: ${{ inputs.apptest_exclude_list }}
-      disable_list: ${{ inputs.apptest_disable_list }}
+      system_list:         ${{ inputs.apptest_system_list }}
+      include_list:        ${{ inputs.apptest_include_list }}
+      exclude_list:        ${{ inputs.apptest_exclude_list }}
+      disable_list:        ${{ inputs.apptest_disable_list }}
 
   UnitTesting:
     uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@dev
@@ -211,9 +214,9 @@ jobs:
       coverage_report_json_filename:  ${{ needs.ConfigParams.outputs.coverage_report_json_filename }}
       coverage_html_artifact:         ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_html }}
       coverage_report_html_directory: ${{ needs.ConfigParams.outputs.coverage_report_html_directory }}
-
     secrets:
-      codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CODACY_TOKEN:  ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   PublishTestResults:
     uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@dev
@@ -225,6 +228,8 @@ jobs:
       additional_merge_args: '-d "--pytest=rewrite-dunder-init;reduce-depth:pytest.tests.unit"'
       merged_junit_filename: ${{ needs.ConfigParams.outputs.unittest_merged_report_xml_filename }}
       merged_junit_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 #  VerifyDocs:
 #    uses: pyTooling/Actions/.github/workflows/VerifyDocs.yml@dev

--- a/.github/workflows/CompletePipeline.yml
+++ b/.github/workflows/CompletePipeline.yml
@@ -93,6 +93,21 @@ on:
         required: false
         default: ''
         type: string
+      codecov:
+        description: 'Publish merged coverage and unittest reports to Codecov.'
+        required: false
+        default: false
+        type: boolean
+      codacy:
+        description: 'Publish merged coverage report to Codacy.'
+        required: false
+        default: false
+        type: boolean
+      dorny:
+        description: 'Publish merged unittest report via Dorny Test-Reporter.'
+        required: false
+        default: false
+        type: boolean
       cleanup:
         description: 'Cleanup artifacts afterwards.'
         required: false
@@ -214,6 +229,8 @@ jobs:
       coverage_report_json_filename:  ${{ needs.ConfigParams.outputs.coverage_report_json_filename }}
       coverage_html_artifact:         ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_html }}
       coverage_report_html_directory: ${{ needs.ConfigParams.outputs.coverage_report_html_directory }}
+      codecov:                        ${{ inputs.codecov }}
+      codacy:                         ${{ inputs.codacy }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       CODACY_TOKEN:  ${{ secrets.CODACY_PROJECT_TOKEN }}
@@ -225,11 +242,15 @@ jobs:
       - UnitTestingParams
       - UnitTesting
     with:
-      additional_merge_args: '-d "--pytest=rewrite-dunder-init;reduce-depth:pytest.tests.unit"'
-      merged_junit_filename: ${{ needs.ConfigParams.outputs.unittest_merged_report_xml_filename }}
-      merged_junit_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}
+      additional_merge_args:  '-d "--pytest=rewrite-dunder-init;reduce-depth:pytest.tests.unit"'
+      testsuite-summary-name: ${{ inputs.package_name }}
+      merged_junit_filename:  ${{ needs.ConfigParams.outputs.unittest_merged_report_xml_filename }}
+      merged_junit_artifact:  ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}
+      dorny:                  ${{ inputs.dorny }}
+      codecov:                ${{ inputs.codecov }}
+
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN:          ${{ secrets.CODECOV_TOKEN }}
 
 #  VerifyDocs:
 #    uses: pyTooling/Actions/.github/workflows/VerifyDocs.yml@dev

--- a/.github/workflows/ExtractConfiguration.yml
+++ b/.github/workflows/ExtractConfiguration.yml
@@ -68,6 +68,15 @@ on:
       unittest_report_xml:
         description: ""
         value: ${{ jobs.Extract.outputs.unittest_report_xml }}
+      unittest_merged_report_xml_directory:
+        description: ""
+        value: ${{ jobs.Extract.outputs.unittest_merged_report_xml_directory }}
+      unittest_merged_report_xml_filename:
+        description: ""
+        value: ${{ jobs.Extract.outputs.unittest_merged_report_xml_filename }}
+      unittest_merged_report_xml:
+        description: ""
+        value: ${{ jobs.Extract.outputs.unittest_merged_report_xml }}
       coverage_report_html_directory:
         description: ""
         value: ${{ jobs.Extract.outputs.coverage_report_html_directory }}
@@ -95,19 +104,22 @@ jobs:
     name: 📓 Extract configurations from pyproject.toml
     runs-on: "ubuntu-${{ inputs.ubuntu_image_version }}"
     outputs:
-      package_fullname:               ${{ steps.getPackageName.outputs.package_fullname }}
-      package_directory:              ${{ steps.getPackageName.outputs.package_directory }}
-      mypy_prepare_command:           ${{ steps.getPackageName.outputs.mypy_prepare_command }}
-      unittest_report_xml_directory:  ${{ steps.getVariables.outputs.unittest_report_xml_directory }}
-      unittest_report_xml_filename:   ${{ steps.getVariables.outputs.unittest_report_xml_filename }}
-      unittest_report_xml:            ${{ steps.getVariables.outputs.unittest_report_xml }}
-      coverage_report_html_directory: ${{ steps.getVariables.outputs.coverage_report_html_directory }}
-      coverage_report_xml_directory:  ${{ steps.getVariables.outputs.coverage_report_xml_directory }}
-      coverage_report_xml_filename:   ${{ steps.getVariables.outputs.coverage_report_xml_filename }}
-      coverage_report_xml:            ${{ steps.getVariables.outputs.coverage_report_xml }}
-      coverage_report_json_directory: ${{ steps.getVariables.outputs.coverage_report_json_directory }}
-      coverage_report_json_filename:  ${{ steps.getVariables.outputs.coverage_report_json_filename }}
-      coverage_report_json:           ${{ steps.getVariables.outputs.coverage_report_json }}
+      package_fullname:                     ${{ steps.getPackageName.outputs.package_fullname }}
+      package_directory:                    ${{ steps.getPackageName.outputs.package_directory }}
+      mypy_prepare_command:                 ${{ steps.getPackageName.outputs.mypy_prepare_command }}
+      unittest_report_xml_directory:        ${{ steps.getVariables.outputs.unittest_report_xml_directory }}
+      unittest_report_xml_filename:         ${{ steps.getVariables.outputs.unittest_report_xml_filename }}
+      unittest_report_xml:                  ${{ steps.getVariables.outputs.unittest_report_xml }}
+      unittest_merged_report_xml_directory: ${{ steps.getVariables.outputs.unittest_merged_report_xml_directory }}
+      unittest_merged_report_xml_filename:  ${{ steps.getVariables.outputs.unittest_merged_report_xml_filename }}
+      unittest_merged_report_xml:           ${{ steps.getVariables.outputs.unittest_merged_report_xml }}
+      coverage_report_html_directory:       ${{ steps.getVariables.outputs.coverage_report_html_directory }}
+      coverage_report_xml_directory:        ${{ steps.getVariables.outputs.coverage_report_xml_directory }}
+      coverage_report_xml_filename:         ${{ steps.getVariables.outputs.coverage_report_xml_filename }}
+      coverage_report_xml:                  ${{ steps.getVariables.outputs.coverage_report_xml }}
+      coverage_report_json_directory:       ${{ steps.getVariables.outputs.coverage_report_json_directory }}
+      coverage_report_json_filename:        ${{ steps.getVariables.outputs.coverage_report_json_filename }}
+      coverage_report_json:                 ${{ steps.getVariables.outputs.coverage_report_json }}
 
     steps:
       - name: ⏬ Checkout repository
@@ -178,6 +190,7 @@ jobs:
                 pyProjectSettings = tomli_load(file)
 
               unittestXMLFile =       Path(pyProjectSettings["tool"]["pytest"]["junit_xml"])
+              mergedUnittestXMLFile = Path(pyProjectSettings["tool"]["pyedaa-reports"]["junit_xml"])
               coverageHTMLDirectory = Path(pyProjectSettings["tool"]["coverage"]["html"]["directory"])
               coverageXMLFile =       Path(pyProjectSettings["tool"]["coverage"]["xml"]["output"])
               coverageJSONFile=       Path(pyProjectSettings["tool"]["coverage"]["json"]["output"])
@@ -209,6 +222,9 @@ jobs:
               unittest_report_xml_directory={unittestXMLFile.parent.as_posix()}
               unittest_report_xml_filename={unittestXMLFile.name}
               unittest_report_xml={unittestXMLFile.as_posix()}
+              unittest_merged_report_xml_directory={mergedUnittestXMLFile.parent.as_posix()}
+              unittest_merged_report_xml_filename={mergedUnittestXMLFile.name}
+              unittest_merged_report_xml={mergedUnittestXMLFile.as_posix()}
               coverage_report_html_directory={coverageHTMLDirectory.as_posix()}
               coverage_report_xml_directory={coverageXMLFile.parent.as_posix()}
               coverage_report_xml_filename={coverageXMLFile.name}
@@ -218,4 +234,4 @@ jobs:
               coverage_report_json={coverageJSONFile.as_posix()}
             """))
 
-          print(f"DEBUG:\n  unittest xml:  {unittestXMLFile}\n  coverage html: {coverageHTMLDirectory}\n  coverage xml:  {coverageXMLFile}\n  coverage json: {coverageJSONFile}")
+          print(f"DEBUG:\n  unittest xml:        {unittestXMLFile}\n  merged unittest xml: {mergedUnittestXMLFile}\n  coverage html:       {coverageHTMLDirectory}\n  coverage xml:        {coverageXMLFile}\n  coverage json:       {coverageJSONFile}")

--- a/.github/workflows/ExtractConfiguration.yml
+++ b/.github/workflows/ExtractConfiguration.yml
@@ -32,7 +32,7 @@ on:
       python_version:
         description: 'Python version.'
         required: false
-        default: '3.12'
+        default: '3.13'
         type: string
       package_namespace:
         description: 'Name of the tool''s namespace.'

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -33,7 +33,7 @@ on:
       python_version:
         description: 'Python version.'
         required: false
-        default: '3.12'
+        default: '3.13'
         type: string
       requirements:
         description: 'Python dependencies to be installed through pip; if empty, use pyproject.toml through build.'

--- a/.github/workflows/PublishCoverageResults.yml
+++ b/.github/workflows/PublishCoverageResults.yml
@@ -48,15 +48,40 @@ on:
         required: false
         default: ''
         type: string
+      coverage_report_xml_directory:
+        description: 'Directory containing the XML coverage report file.'
+        required: false
+        default: 'report/coverage'
+        type: string
+      coverage_report_xml_filename:
+        description: 'Filename of the XML coverage report file.'
+        required: false
+        default: 'coverage.xml'
+        type: string
       coverage_json_artifact:
         description: 'Name of the JSON coverage artifact.'
         required: false
         default: ''
         type: string
+      coverage_report_json_directory:
+        description: 'Directory containing the JSON coverage report file.'
+        required: false
+        default: 'report/coverage'
+        type: string
+      coverage_report_json_filename:
+        description: 'Filename of the JSON coverage report file.'
+        required: false
+        default: 'coverage.json'
+        type: string
       coverage_html_artifact:
         description: 'Name of the HTML coverage artifact.'
         required: false
         default: ''
+        type: string
+      coverage_report_html_directory:
+        description: 'HTML root directory of the generated coverage report.'
+        required: false
+        default: 'report/coverage/html'
         type: string
     secrets:
       codacy_token:
@@ -89,66 +114,6 @@ jobs:
       - name: 🔧 Install coverage and tomli
         run: |
           python -m pip install -U --disable-pip-version-check --break-system-packages coverage[toml] tomli
-
-      - name: 🔁 Extract configurations from pyproject.toml
-        id: getVariables
-        shell: python
-        run: |
-          from os       import getenv
-          from pathlib  import Path
-          from sys      import version
-          from textwrap import dedent
-
-          print(f"Python: {version}")
-
-          from tomli import load as tomli_load
-
-          htmlDirectory = Path("htmlcov")
-          xmlFile =  Path("./coverage.xml")
-          jsonFile = Path("./coverage.json")
-          coverageRC = "${{ inputs.coverage_config }}".strip()
-
-          # Read output paths from 'pyproject.toml' file
-          if coverageRC == "pyproject.toml":
-            pyProjectFile =  Path("pyproject.toml")
-            if pyProjectFile.exists():
-              with pyProjectFile.open("rb") as file:
-                pyProjectSettings = tomli_load(file)
-
-              htmlDirectory = Path(pyProjectSettings["tool"]["coverage"]["html"]["directory"])
-              xmlFile       = Path(pyProjectSettings["tool"]["coverage"]["xml"]["output"])
-              jsonFile      = Path(pyProjectSettings["tool"]["coverage"]["json"]["output"])
-            else:
-              print(f"File '{pyProjectFile}' not found.")
-              print(f"::error title=FileNotFoundError::File '{pyProjectFile}' not found.")
-              exit(1)
-
-          # Read output paths from '.coveragerc' file
-          elif len(coverageRC) > 0:
-            coverageRCFile = Path(coverageRC)
-            if coverageRCFile.exists():
-              with coverageRCFile.open("rb") as file:
-                coverageRCSettings = tomli_load(file)
-
-              htmlDirectory = Path(coverageRCSettings["html"]["directory"])
-              xmlFile       = Path(coverageRCSettings["xml"]["output"])
-              jsonFile      = Path(coverageRCSettings["json"]["output"])
-            else:
-              print(f"File '{coverageRCFile}' not found.")
-              print(f"::error title=FileNotFoundError::File '{coverageRCFile}' not found.")
-              exit(1)
-
-          # Write jobs to special file
-          github_output = Path(getenv("GITHUB_OUTPUT"))
-          print(f"GITHUB_OUTPUT: {github_output}")
-          with github_output.open("a+", encoding="utf-8") as f:
-            f.write(dedent(f"""\
-              coverage_report_html_directory={htmlDirectory.as_posix()}
-              coverage_report_xml={xmlFile}
-              coverage_report_json={jsonFile}
-            """))
-
-          print(f"DEBUG:\n  html={htmlDirectory}\n  xml={xmlFile}\n  json={jsonFile}")
 
       - name: Rename .coverage files and move them all into 'coverage/'
         run: |
@@ -193,7 +158,8 @@ jobs:
         continue-on-error: true
         with:
           name: ${{ inputs.coverage_xml_artifact }}
-          path: ${{ steps.getVariables.outputs.coverage_report_xml }}
+          working-directory: ${{ inputs.coverage_report_xml_directory }}
+          path: ${{ inputs.coverage_report_xml_filename }}
           if-no-files-found: error
           retention-days: 1
 
@@ -203,7 +169,8 @@ jobs:
         continue-on-error: true
         with:
           name: ${{ inputs.coverage_json_artifact }}
-          path: ${{ steps.getVariables.outputs.coverage_report_json }}
+          working-directory: ${{ inputs.coverage_report_json_directory }}
+          path: ${{ inputs.coverage_report_json_filename }}
           if-no-files-found: error
           retention-days: 1
 
@@ -213,7 +180,7 @@ jobs:
         continue-on-error: true
         with:
           name: ${{ inputs.coverage_html_artifact }}
-          working-directory: ${{ steps.getVariables.outputs.coverage_report_html_directory }}
+          working-directory: ${{ inputs.coverage_report_html_directory }}
           path: '*'
           if-no-files-found: error
           retention-days: 1
@@ -223,7 +190,7 @@ jobs:
         if: inputs.CodeCov == true
         continue-on-error: true
         with:
-          files: ${{ steps.getVariables.outputs.coverage_report_xml }}
+          files: ${{ inputs.coverage_report_xml_directory }}/${{ inputs.coverage_report_xml_filename }}
           flags: unittests
           env_vars: PYTHON
 
@@ -233,4 +200,4 @@ jobs:
         continue-on-error: true
         with:
           project-token: ${{ secrets.codacy_token }}
-          coverage-reports: ${{ steps.getVariables.outputs.coverage_report_xml }}
+          coverage-reports: ${{ inputs.coverage_report_xml_directory }}/${{ inputs.coverage_report_xml_filename }}

--- a/.github/workflows/PublishCoverageResults.yml
+++ b/.github/workflows/PublishCoverageResults.yml
@@ -83,9 +83,22 @@ on:
         required: false
         default: 'report/coverage/html'
         type: string
+      codecov:
+        description: 'Publish merged coverage report to Codecov.'
+        required: false
+        default: true
+        type: boolean
+      codacy:
+        description: 'Publish merged coverage report to Codacy.'
+        required: false
+        default: true
+        type: boolean
     secrets:
-      codacy_token:
-        description: 'Token to push result to codacy.'
+      CODECOV_TOKEN:
+        description: 'Token to push result to Codecov.'
+        required: true
+      CODACY_TOKEN:
+        description: 'Token to push result to Codacy.'
         required: true
 
 jobs:
@@ -128,7 +141,7 @@ jobs:
         run: coverage report --rcfile=pyproject.toml --data-file=.coverage
 
       - name: Convert to XML format (Cobertura)
-        if: inputs.coverage_xml_artifact != ''
+        if: inputs.coverage_xml_artifact != '' || inputs.codecov || inputs.codacy
         run: coverage xml --data-file=.coverage
 
       - name: Convert to JSON format
@@ -187,17 +200,20 @@ jobs:
 
       - name: 📊 Publish code coverage at CodeCov
         uses: codecov/codecov-action@v5
-        if: inputs.CodeCov == true
+        if: inputs.codecov
         continue-on-error: true
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
           files: ${{ inputs.coverage_report_xml_directory }}/${{ inputs.coverage_report_xml_filename }}
           flags: unittests
           env_vars: PYTHON
+          fail_ci_if_error: true
 
       - name: 📉 Publish code coverage at Codacy
         uses: codacy/codacy-coverage-reporter-action@v1
-        if: inputs.Codacy == true
+        if: inputs.codacy
         continue-on-error: true
         with:
-          project-token: ${{ secrets.codacy_token }}
+          project-token: ${{ secrets.CODACY_TOKEN }}
           coverage-reports: ${{ inputs.coverage_report_xml_directory }}/${{ inputs.coverage_report_xml_filename }}

--- a/.github/workflows/PublishCoverageResults.yml
+++ b/.github/workflows/PublishCoverageResults.yml
@@ -86,12 +86,12 @@ on:
       codecov:
         description: 'Publish merged coverage report to Codecov.'
         required: false
-        default: true
+        default: false
         type: boolean
       codacy:
         description: 'Publish merged coverage report to Codacy.'
         required: false
-        default: true
+        default: false
         type: boolean
     secrets:
       CODECOV_TOKEN:

--- a/.github/workflows/PublishOnPyPI.yml
+++ b/.github/workflows/PublishOnPyPI.yml
@@ -33,7 +33,7 @@ on:
       python_version:
         description: 'Python version.'
         required: false
-        default: '3.12'
+        default: '3.13'
         type: string
       requirements:
         description: 'Python dependencies to be installed through pip.'

--- a/.github/workflows/PublishTestResults.yml
+++ b/.github/workflows/PublishTestResults.yml
@@ -59,6 +59,15 @@ on:
         required: false
         default: 'Unit Test Results'
         type: string
+      codecov:
+        description: 'Publish merged unittest results to Codecov.'
+        required: false
+        default: true
+        type: boolean
+    secrets:
+      CODECOV_TOKEN:
+        description: 'Token to push result to Codecov.'
+        required: true
 
 jobs:
   PublishTestResults:
@@ -103,6 +112,16 @@ jobs:
           name: ${{ inputs.report_title }}
           path: ${{ inputs.merged_junit_filename }}
           reporter: java-junit
+
+      - name: 📊 Publish unittest results at CodeCov
+        uses: codecov/test-results-action@v1
+        if: inputs.codecov
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
+          files: ${{ inputs.merged_junit_filename }}
+          fail_ci_if_error: true
+          verbose: true
 
       - name: 📤 Upload merged 'JUnit Test Summary' artifact
         uses: pyTooling/upload-artifact@v4

--- a/.github/workflows/PublishTestResults.yml
+++ b/.github/workflows/PublishTestResults.yml
@@ -34,6 +34,11 @@ on:
         required: false
         default: '*-UnitTestReportSummary-XML-*'
         type: string
+      merged_junit_filename:
+        description: 'Filename of the merged JUnit Test Summary.'
+        required: false
+        default: 'Unittesting.xml'
+        type: string
       merged_junit_artifact:
         description: 'Name of the merged JUnit Test Summary artifact.'
         required: false
@@ -87,16 +92,16 @@ jobs:
 
       - name: 🔁 Merge JUnit Unit Test Summaries
         run: |
-          pyedaa-reports -v unittest "--merge=pyTest-JUnit:junit/*.xml" ${{ inputs.additional_merge_args }} "--output=pyTest-JUnit:Unittesting.xml"
-          printf "%s\n" "cat Unittesting.xml"
-          cat Unittesting.xml
+          pyedaa-reports -v unittest "--merge=pyTest-JUnit:junit/*.xml" ${{ inputs.additional_merge_args }} "--output=pyTest-JUnit:${{ inputs.merged_junit_filename }}"
+          printf "%s\n" "cat ${{ inputs.merged_junit_filename }}"
+          cat ${{ inputs.merged_junit_filename }}
 
       - name: 📊 Publish Unit Test Results
         uses: dorny/test-reporter@v1
         if: inputs.publish && inputs.report_title != ''
         with:
           name: ${{ inputs.report_title }}
-          path: Unittesting.xml
+          path: ${{ inputs.merged_junit_filename }}
           reporter: java-junit
 
       - name: 📤 Upload merged 'JUnit Test Summary' artifact
@@ -104,6 +109,7 @@ jobs:
         if: inputs.merged_junit_artifact != ''
         with:
           name: ${{ inputs.merged_junit_artifact }}
-          path: Unittesting.xml
+          path: ${{ inputs.merged_junit_filename }}
           if-no-files-found: error
           retention-days: 1
+          investigate: true

--- a/.github/workflows/PublishTestResults.yml
+++ b/.github/workflows/PublishTestResults.yml
@@ -49,6 +49,11 @@ on:
         required: false
         default: '"--pytest=rewrite-dunder-init;reduce-depth:pytest.tests.unit"'
         type: string
+      testsuite-summary-name:
+        description: 'Set TestsuiteSummary name.'
+        required: false
+        default: ''
+        type: string
       publish:
         description: 'Publish test report summary via Dorny Test-Reporter'
         required: false
@@ -59,6 +64,11 @@ on:
         required: false
         default: 'Unit Test Results'
         type: string
+      dorny:
+        description: 'Publish merged unittest results via Dorny Test-Reporter.'
+        required: false
+        default: true
+        type: boolean
       codecov:
         description: 'Publish merged unittest results to Codecov.'
         required: false
@@ -83,7 +93,7 @@ jobs:
         uses: pyTooling/download-artifact@v4
         with:
           pattern: ${{ inputs.unittest_artifacts_pattern }}
-          path: artifacts
+          path:    artifacts
 
       - name: 🔎 Inspect extracted artifact (tarball)
         run: |
@@ -101,13 +111,13 @@ jobs:
 
       - name: 🔁 Merge JUnit Unit Test Summaries
         run: |
-          pyedaa-reports -v unittest "--merge=pyTest-JUnit:junit/*.xml" ${{ inputs.additional_merge_args }} "--output=pyTest-JUnit:${{ inputs.merged_junit_filename }}"
+          pyedaa-reports -v unittest "--name=${{ inputs.testsuite-summary-name }}" "--merge=pyTest-JUnit:junit/*.xml" ${{ inputs.additional_merge_args }} "--output=pyTest-JUnit:${{ inputs.merged_junit_filename }}"
           printf "%s\n" "cat ${{ inputs.merged_junit_filename }}"
           cat ${{ inputs.merged_junit_filename }}
 
       - name: 📊 Publish Unit Test Results
         uses: dorny/test-reporter@v2
-        if: inputs.publish && inputs.report_title != ''
+        if: (inputs.dorny || inputs.publish) && inputs.report_title != ''
         with:
           name: ${{ inputs.report_title }}
           path: ${{ inputs.merged_junit_filename }}

--- a/.github/workflows/PublishTestResults.yml
+++ b/.github/workflows/PublishTestResults.yml
@@ -121,7 +121,6 @@ jobs:
           disable_search: true
           files: ${{ inputs.merged_junit_filename }}
           fail_ci_if_error: true
-          verbose: true
 
       - name: 📤 Upload merged 'JUnit Test Summary' artifact
         uses: pyTooling/upload-artifact@v4

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -44,9 +44,9 @@ jobs:
           RELEASE_VERSION=${GIT_TAG#v}
           RELEASE_DATETIME="$(date --utc '+%d.%m.%Y - %H:%M:%S')"
           # write to step outputs
-          echo "gitTag=${GIT_TAG}" >> $GITHUB_OUTPUT
-          echo "version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
-          echo "datetime=${RELEASE_DATETIME}" >> $GITHUB_OUTPUT
+          printf "%s\n" "gitTag=${GIT_TAG}" >> $GITHUB_OUTPUT
+          printf "%s\n" "version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+          printf "%s\n" "datetime=${RELEASE_DATETIME}" >> $GITHUB_OUTPUT
 
       - name: 📑 Create Release Page
         uses: actions/create-release@v1

--- a/.github/workflows/SphinxDocumentation.yml
+++ b/.github/workflows/SphinxDocumentation.yml
@@ -113,6 +113,7 @@ jobs:
         with:
           name: ${{ inputs.coverage_json_artifact }}
           path: ${{ inputs.coverage_report_json_directory }}
+          investigate: true
 
       - name: ☑ Generate HTML documentation
         if: inputs.html_artifact != ''
@@ -163,6 +164,7 @@ jobs:
         with:
           name: ${{ inputs.unittest_xml_artifact }}
           path: ${{ inputs.unittest_xml_directory }}
+          investigate: true
 
       - name: 📥 Download artifacts '${{ inputs.coverage_json_artifact }}' from 'PublishCoverageResults' job
         uses: pyTooling/download-artifact@v4
@@ -170,6 +172,7 @@ jobs:
         with:
           name: ${{ inputs.coverage_json_artifact }}
           path: ${{ inputs.coverage_report_json_directory }}
+          investigate: true
 
       - name: ☑ Generate LaTeX documentation
         if: inputs.latex_artifact != ''

--- a/.github/workflows/SphinxDocumentation.yml
+++ b/.github/workflows/SphinxDocumentation.yml
@@ -32,7 +32,7 @@ on:
       python_version:
         description: 'Python version.'
         required: false
-        default: '3.12'
+        default: '3.13'
         type: string
       requirements:
         description: 'Python dependencies to be installed through pip.'

--- a/.github/workflows/SphinxDocumentation.yml
+++ b/.github/workflows/SphinxDocumentation.yml
@@ -183,8 +183,8 @@ jobs:
       - name: Workaround I - https://github.com/sphinx-doc/sphinx/issues/13190
         if: inputs.latex_artifact != ''
         run: |
-          printf "Changing directory to 'doc/_build/latex' ...\n"
-          cd doc/_build/latex
+          printf "Changing directory to '${{ inputs.doc_directory || '.' }}/_build/latex' ...\n"
+          cd ${{ inputs.doc_directory || '.' }}/_build/latex
 
           MIMETYPE_EXTENSIONS=(
             "image/png:png"
@@ -232,8 +232,8 @@ jobs:
       - name: Workaround II - https://github.com/sphinx-doc/sphinx/issues/13189
         if: inputs.latex_artifact != ''
         run: |
-          printf "Changing directory to 'doc/_build/latex' ...\n"
-          cd doc/_build/latex
+          printf "Changing directory to '${{ inputs.doc_directory || '.' }}/_build/latex' ...\n"
+          cd ${{ inputs.doc_directory || '.' }}/_build/latex
 
           printf "Searching for downloaded images, that need normalization ...\n"
           for imageExt in png svg jpg jpeg; do

--- a/.github/workflows/SphinxDocumentation.yml
+++ b/.github/workflows/SphinxDocumentation.yml
@@ -105,6 +105,7 @@ jobs:
         with:
           name: ${{ inputs.unittest_xml_artifact }}
           path: ${{ inputs.unittest_xml_directory }}
+          investigate: true
 
       - name: 📥 Download artifacts '${{ inputs.coverage_json_artifact }}' from 'PublishCoverageResults' job
         uses: pyTooling/download-artifact@v4

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -33,7 +33,7 @@ on:
       python_version:
         description: 'Python version.'
         required: false
-        default: '3.12'
+        default: '3.13'
         type: string
       requirements:
         description: 'Python dependencies to be installed through pip.'

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -358,6 +358,7 @@ jobs:
 
       - name: ✅ Run unit tests (Windows)
         if: matrix.system == 'windows'
+        continue-on-error: true
         run: |
           $env:ENVIRONMENT_NAME = "${{ matrix.envname }}"
           $env:PYTHONPATH = (Get-Location).ToString()

--- a/.github/workflows/VerifyDocs.yml
+++ b/.github/workflows/VerifyDocs.yml
@@ -33,7 +33,7 @@ on:
       python_version:
         description: 'Python version.'
         required: false
-        default: '3.12'
+        default: '3.13'
         type: string
 
 jobs:

--- a/.github/workflows/_Checking_JobTemplates.yml
+++ b/.github/workflows/_Checking_JobTemplates.yml
@@ -111,7 +111,8 @@ jobs:
       coverage_html_artifact:         ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_html }}
       coverage_report_html_directory: ${{ needs.ConfigParams.outputs.coverage_report_html_directory }}
     secrets:
-      codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CODACY_TOKEN:  ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   PublishTestResults:
     uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@dev
@@ -122,6 +123,8 @@ jobs:
     with:
       additional_merge_args: '-d "--pytest=rewrite-dunder-init;reduce-depth:pytest.tests.unit;reduce-depth:pytest.tests.platform"'
       merged_junit_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 #  VerifyDocs:
 #    uses: pyTooling/Actions/.github/workflows/VerifyDocs.yml@dev

--- a/.github/workflows/_Checking_JobTemplates.yml
+++ b/.github/workflows/_Checking_JobTemplates.yml
@@ -96,14 +96,20 @@ jobs:
   PublishCoverageResults:
     uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@dev
     needs:
+      - ConfigParams
       - UnitTestingParams
       - UnitTesting
       - PlatformTesting
     with:
-      coverage_sqlite_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_sqlite }}
-      coverage_xml_artifact:    ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_xml }}
-      coverage_json_artifact:   ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_json }}
-      coverage_html_artifact:   ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_html }}
+      coverage_sqlite_artifact:       ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_sqlite }}
+      coverage_xml_artifact:          ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_xml }}
+      coverage_report_xml_directory:  ${{ needs.ConfigParams.outputs.coverage_report_xml_directory }}
+      coverage_report_xml_filename:   ${{ needs.ConfigParams.outputs.coverage_report_xml_filename }}
+      coverage_json_artifact:         ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_json }}
+      coverage_report_json_directory: ${{ needs.ConfigParams.outputs.coverage_report_json_directory }}
+      coverage_report_json_filename:  ${{ needs.ConfigParams.outputs.coverage_report_json_filename }}
+      coverage_html_artifact:         ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_html }}
+      coverage_report_html_directory: ${{ needs.ConfigParams.outputs.coverage_report_html_directory }}
     secrets:
       codacy_token: ${{ secrets.CODACY_PROJECT_TOKEN }}
 

--- a/.github/workflows/_Checking_JobTemplates.yml
+++ b/.github/workflows/_Checking_JobTemplates.yml
@@ -30,7 +30,7 @@ jobs:
       - ConfigParams
       - UnitTestingParams
     with:
-      jobs: ${{ needs.UnitTestingParams.outputs.python_jobs }}
+      jobs:                           ${{ needs.UnitTestingParams.outputs.python_jobs }}
       unittest_report_xml_directory:  ${{ needs.ConfigParams.outputs.unittest_report_xml_directory }}
       unittest_report_xml_filename:   ${{ needs.ConfigParams.outputs.unittest_report_xml_filename }}
       coverage_report_html_directory: ${{ needs.ConfigParams.outputs.coverage_report_html_directory }}
@@ -47,9 +47,9 @@ jobs:
       - ConfigParams
       - PlatformTestingParams
     with:
-      jobs: ${{ needs.PlatformTestingParams.outputs.python_jobs }}
+      jobs:                           ${{ needs.PlatformTestingParams.outputs.python_jobs }}
 #      tests_directory: ""
-      unittest_directory: platform
+      unittest_directory:             platform
       unittest_report_xml_directory:  ${{ needs.ConfigParams.outputs.unittest_report_xml_directory }}
       unittest_report_xml_filename:   ${{ needs.ConfigParams.outputs.unittest_report_xml_filename }}
       coverage_report_html_directory: ${{ needs.ConfigParams.outputs.coverage_report_html_directory }}
@@ -70,7 +70,7 @@ jobs:
       commands: |
         ${{ needs.ConfigParams.outputs.mypy_prepare_command }}
         mypy --html-report htmlmypy -p ${{ needs.ConfigParams.outputs.package_fullname }}
-      html_report: 'htmlmypy'
+      html_report:   'htmlmypy'
       html_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).statictyping_html }}
 
   DocCoverage:
@@ -80,7 +80,7 @@ jobs:
       - UnitTestingParams
     with:
       python_version: ${{ needs.UnitTestingParams.outputs.python_version }}
-      directory: ${{ needs.ConfigParams.outputs.package_directors }}
+      directory     : ${{ needs.ConfigParams.outputs.package_directors }}
 #      fail_below: 70
 
   Package:
@@ -91,7 +91,7 @@ jobs:
       - PlatformTesting
     with:
       python_version: ${{ needs.UnitTestingParams.outputs.python_version }}
-      artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).package_all }}
+      artifact:       ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).package_all }}
 
   PublishCoverageResults:
     uses: pyTooling/Actions/.github/workflows/PublishCoverageResults.yml@dev
@@ -110,6 +110,8 @@ jobs:
       coverage_report_json_filename:  ${{ needs.ConfigParams.outputs.coverage_report_json_filename }}
       coverage_html_artifact:         ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_html }}
       coverage_report_html_directory: ${{ needs.ConfigParams.outputs.coverage_report_html_directory }}
+      codecov:                        true
+      codacy:                         true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       CODACY_TOKEN:  ${{ secrets.CODACY_PROJECT_TOKEN }}
@@ -117,14 +119,18 @@ jobs:
   PublishTestResults:
     uses: pyTooling/Actions/.github/workflows/PublishTestResults.yml@dev
     needs:
+      - ConfigParams
       - UnitTestingParams
       - UnitTesting
       - PlatformTesting
     with:
-      additional_merge_args: '-d "--pytest=rewrite-dunder-init;reduce-depth:pytest.tests.unit;reduce-depth:pytest.tests.platform"'
-      merged_junit_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}
+      additional_merge_args:  '-d "--pytest=rewrite-dunder-init;reduce-depth:pytest.tests.unit;reduce-depth:pytest.tests.platform"'
+      testsuite-summary-name: ${{ needs.ConfigParams.outputs.package_fullname }}
+      merged_junit_artifact:  ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}
+      codecov:                true
+      dorny:                  true
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN:          ${{ secrets.CODECOV_TOKEN }}
 
 #  VerifyDocs:
 #    uses: pyTooling/Actions/.github/workflows/VerifyDocs.yml@dev

--- a/.github/workflows/_Checking_NamespacePackage_Pipeline.yml
+++ b/.github/workflows/_Checking_NamespacePackage_Pipeline.yml
@@ -10,6 +10,9 @@ jobs:
     with:
       package_namespace: pyExamples
       package_name:      Extensions
+      codecov:           true
+      codacy:            true
+      dorny:             true
     secrets:
       PYPI_TOKEN:           ${{ secrets.PYPI_TOKEN }}
       CODECOV_TOKEN:        ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/_Checking_NamespacePackage_Pipeline.yml
+++ b/.github/workflows/_Checking_NamespacePackage_Pipeline.yml
@@ -12,4 +12,5 @@ jobs:
       package_name:      Extensions
     secrets:
       PYPI_TOKEN:           ${{ secrets.PYPI_TOKEN }}
+      CODECOV_TOKEN:        ${{ secrets.CODECOV_TOKEN }}
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/_Checking_SimplePackage_Pipeline.yml
+++ b/.github/workflows/_Checking_SimplePackage_Pipeline.yml
@@ -9,6 +9,9 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/CompletePipeline.yml@dev
     with:
       package_name: pyDummy
+      codecov: true
+      codacy:  true
+      dorny:   true
       cleanup: false
     secrets:
       PYPI_TOKEN:           ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/_Checking_SimplePackage_Pipeline.yml
+++ b/.github/workflows/_Checking_SimplePackage_Pipeline.yml
@@ -9,6 +9,7 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/CompletePipeline.yml@dev
     with:
       package_name: pyDummy
+      cleanup: false
     secrets:
       PYPI_TOKEN:           ${{ secrets.PYPI_TOKEN }}
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/_Checking_SimplePackage_Pipeline.yml
+++ b/.github/workflows/_Checking_SimplePackage_Pipeline.yml
@@ -12,4 +12,5 @@ jobs:
       cleanup: false
     secrets:
       PYPI_TOKEN:           ${{ secrets.PYPI_TOKEN }}
+      CODECOV_TOKEN:        ${{ secrets.CODECOV_TOKEN }}
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 -r ../requirements.txt
 
-pyTooling ~= 8.3
+pyTooling ~= 8.4
 
 # Enforce latest version on ReadTheDocs
 sphinx ~= 8.2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 -r ../requirements.txt
 
-pyTooling ~= 8.2
+pyTooling ~= 8.3
 
 # Enforce latest version on ReadTheDocs
 sphinx ~= 8.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-  "setuptools ~= 75.8",
+  "setuptools ~= 76.0",
   "wheel ~= 0.45",
-  "pyTooling ~= 8.2"
+  "pyTooling ~= 8.3"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools ~= 78.1",
   "wheel ~= 0.45",
-  "pyTooling ~= 8.3"
+  "pyTooling ~= 8.4"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools ~= 77.0",
+  "setuptools ~= 78.1",
   "wheel ~= 0.45",
   "pyTooling ~= 8.3"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools ~= 76.0",
+  "setuptools ~= 77.0",
   "wheel ~= 0.45",
   "pyTooling ~= 8.3"
 ]
@@ -21,7 +21,10 @@ namespace_packages = true
 html_report = "report/typing"
 
 [tool.pytest]
-junit_xml = "report/unit/TestReportSummary.xml"
+junit_xml = "report/unit/UnittestReportSummary.xml"
+
+[tool.pyedaa-reports]
+junit_xml = "report/unit/unittest.xml"
 
 [tool.pytest.ini_options]
 addopts = "--tb=native"

--- a/releaser/releaser.py
+++ b/releaser/releaser.py
@@ -5,7 +5,7 @@
 #   Unai Martinez-Corral                                                                                               #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2024 The pyTooling Authors                                                                            #
+# Copyright 2020-2025 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyTooling ~= 8.2
+pyTooling ~= 8.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyTooling ~= 8.3
+pyTooling ~= 8.4

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 -r ../requirements.txt
 
 # Coverage collection
-Coverage ~= 7.6
+Coverage ~= 7.7
 
 # Test Runner
 pytest ~= 8.3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,13 +1,13 @@
 -r ../requirements.txt
 
 # Coverage collection
-Coverage ~= 7.7
+Coverage ~= 7.8
 
 # Test Runner
 pytest ~= 8.3
-pytest-cov ~= 6.0
+pytest-cov ~= 6.1
 
 # Static Type Checking
 mypy ~= 1.15
-typing_extensions ~= 4.12
+typing_extensions ~= 4.13
 lxml ~= 5.3


### PR DESCRIPTION
# New Features

* `CompletePipeline.yml`:
  * Added new `codecov` parameter to enable publishing coverage and unittest reports to Codecov.
  * Added new `codacy` parameter to enable publishing coverage reports to Codacy.
  * Added new `dorny` parameter to enable publishing unittest reports via Dorny Test-Reporter.
  * Added new `cleanup` parameter to skip cleanup jobs, thus temporary artifacts aren't removed and can be investigated after pipeline run.
* `ExtractConfiguration.yml`:
  * Provide more output parameters for merged unittest reports in XML format:
    * `unittest_merged_report_xml_directory`
    * `unittest_merged_report_xml_filename`
    * `unittest_merged_report_xml`
* `PublishCoverageResults.yml`
  * Added option `codecov` to activate publishing to Codecov.
  * Added option `codacy` to activate publishing to Codacy.
* `PublishTestResults.yml`
  * Added option `testsuite-summary-name` to set the TestsuiteSummary name.
  * Added option `codecov` to activate publishing to Codecov.
  * Added option `dorny` to activate publishing via Dorny Test-Reporter.  
    (This will replace `publish` in future versions.)

# Changes

* Bumped Python dependencies.
* Updated `dorny/test-reporter` from `v1` to `v2`
* Changed default Python version in all jobs to 3.13.
* `CompletePipeline.yml`
  * Set `testsuite-summary-name` for job `PublishTestResults` to `package_name` from input parameters.
* `PublishCoverageResults.yml`:
  * Removed extraction of configuration variables and use variables provided by the `ExtractConfiguration.yml` job via input parameters.  
    (Reduced code duplication.)
  * New parameters:
    * `coverage_report_xml_directory` and `coverage_report_xml_filename`
    * `coverage_report_json_directory` and `coverage_report_json_filename`
    * `coverage_report_html_directory`


# Bug Fixes

* `CompletePipeline.yml`
  * Forward secrets for Codacy and Codecov.
  * Job `PublishCoverageResults`:
    * Provide parameters `coverage_report_json_directory`, `coverage_report_json_filename` and `coverage_report_html_directory` to the job.
  * `PublishTestResults`:
    * Provide parameters `merged_junit_filename` to the job.
  * `Documentation`
    * Parameter `unittest_xml_artifact`: Use merged unittest results artifact from `PublishTestResults`.
      (Before this change, one specific unittest variant - Ubuntu Python 3.12 - was used.)
* `PublishCoverageResults.yml`:
  * Run coverage report to XML conversion, also if no artifact is activated, but codacy or codecov is active.

# Documentation

*None*

# Unit Tests

* Adjusted code due to parameter changes.
