### PR TITLE
v5.2.0

### DIFF
--- a/.github/workflows/ApplicationTesting.yml
+++ b/.github/workflows/ApplicationTesting.yml
@@ -86,10 +86,10 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Download artifacts '${{ inputs.wheel }}' from 'Package' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ inputs.wheel }}
           path: install

--- a/.github/workflows/BuildTheDocs.yml
+++ b/.github/workflows/BuildTheDocs.yml
@@ -41,7 +41,7 @@ jobs:
         run: printf "::warning title=%s::%s\n" "Deprecated" "'BuildTheDocs.yml' is not maintained anymore. Please switch to 'SphinxDocumentation.yml', 'LaTeXDocumentation.yml' and 'ExtractConfiguration.yml'."
 
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🛳️ Build documentation
         uses: buildthedocs/btd@v0

--- a/.github/workflows/CheckDocumentation.yml
+++ b/.github/workflows/CheckDocumentation.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: "ubuntu-${{ inputs.ubuntu_image_version }}"
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🐍 Setup Python ${{ inputs.python_version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/CompletePipeline.yml
+++ b/.github/workflows/CompletePipeline.yml
@@ -291,6 +291,7 @@ jobs:
       - PublishTestResults
       - PublishCoverageResults
 #      - VerifyDocs
+    if: success() || failure()
     with:
       python_version:                 ${{ needs.UnitTestingParams.outputs.python_version }}
       coverage_report_json_directory: ${{ needs.ConfigParams.outputs.coverage_report_json_directory }}
@@ -305,7 +306,7 @@ jobs:
       - UnitTestingParams
       - PublishCoverageResults
       - PublishTestResults
-    if: inputs.cleanup  == 'true'
+    if: ( success() || failure() ) && inputs.cleanup  == 'true'
     with:
       sqlite_coverage_artifacts_prefix: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_sqlite }}-
       xml_unittest_artifacts_prefix:    ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).unittesting_xml }}-

--- a/.github/workflows/CompletePipeline.yml
+++ b/.github/workflows/CompletePipeline.yml
@@ -245,6 +245,7 @@ jobs:
       - ConfigParams
       - UnitTestingParams
       - UnitTesting
+    if: success() || failure()
     with:
 #      coverage_sqlite_artifact:       ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_sqlite }}
 #      coverage_xml_artifact:          ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).codecoverage_xml }}
@@ -267,6 +268,7 @@ jobs:
       - ConfigParams
       - UnitTestingParams
       - UnitTesting
+    if: success() || failure()
     with:
       testsuite-summary-name: ${{ needs.ConfigParams.outputs.package_fullname }}
       merged_junit_filename:  ${{ needs.ConfigParams.outputs.unittest_merged_report_xml_filename }}

--- a/.github/workflows/CompletePipeline.yml
+++ b/.github/workflows/CompletePipeline.yml
@@ -346,7 +346,7 @@ jobs:
 #      - StaticTypeCheck
       - Package
       - PublishToGitHubPages
-    if: needs.Prepare.outputs.is_release_commit
+    if: needs.Prepare.outputs.is_release_commit && github.event_name != 'schedule'
     permissions:
       contents: write  # required for create tag
       actions:  write  # required for trigger workflow

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -75,7 +75,7 @@ jobs:
         run: printf "::warning title=%s::%s\n" "Deprecated" "'CoverageCollection.yml' is not maintained anymore. Please switch to 'UnitTesting.yml', 'PublishCoverageResults.yml' and 'PublishTestResults.yml'."
 
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
           submodules: true

--- a/.github/workflows/ExtractConfiguration.yml
+++ b/.github/workflows/ExtractConfiguration.yml
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🐍 Setup Python ${{ inputs.python_version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/InstallPackage.yml
+++ b/.github/workflows/InstallPackage.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: 📥 Download artifacts '${{ inputs.wheel }}' from 'Package' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ inputs.wheel }}
           path: install

--- a/.github/workflows/LaTeXDocumentation.yml
+++ b/.github/workflows/LaTeXDocumentation.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: "ubuntu-${{ inputs.ubuntu_image_version }}"
     steps:
       - name: 📥 Download artifacts '${{ inputs.latex_artifact }}' from 'SphinxDocumentation' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ inputs.latex_artifact }}
           path: latex

--- a/.github/workflows/NightlyRelease.yml
+++ b/.github/workflows/NightlyRelease.yml
@@ -101,7 +101,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # The command 'git describe' (used for version) needs the history.
           fetch-depth: 0

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
           submodules: true

--- a/.github/workflows/PrepareJob.yml
+++ b/.github/workflows/PrepareJob.yml
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # The command 'git describe' (used for version) needs the history.
           fetch-depth: 0

--- a/.github/workflows/PublishCoverageResults.yml
+++ b/.github/workflows/PublishCoverageResults.yml
@@ -109,13 +109,13 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
           submodules: true
 
       - name: 📥 Download Artifacts
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           pattern: ${{ inputs.coverage_artifacts_pattern }}
           path: artifacts

--- a/.github/workflows/PublishOnPyPI.yml
+++ b/.github/workflows/PublishOnPyPI.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: 📥 Download artifacts '${{ inputs.artifact }}' from 'Package' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ inputs.artifact }}
           path: dist

--- a/.github/workflows/PublishReleaseNotes.yml
+++ b/.github/workflows/PublishReleaseNotes.yml
@@ -133,7 +133,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # The command 'git describe' (used for version) needs the history.
           fetch-depth: 0

--- a/.github/workflows/PublishTestResults.yml
+++ b/.github/workflows/PublishTestResults.yml
@@ -122,7 +122,9 @@ jobs:
 
       - name: 📊 Publish Unit Test Results
         uses: dorny/test-reporter@v2
+        id: test-reporter
         if: ( inputs.dorny  == 'true' || inputs.publish  == 'true' ) && inputs.report_title != ''
+        continue-on-error: true
         with:
           name: ${{ inputs.report_title }}
           path: ${{ inputs.merged_junit_filename }}
@@ -140,14 +142,6 @@ jobs:
           flags: ${{ inputs.codecov_flags }}
           fail_ci_if_error: true
 
-      - name: Generate error messages
-        run: |
-          if [[ "${{ steps.codecov.outcome }}" == "failure" ]]; then
-            printf "::error title=%s::%s\n" "Publish Unit Test Results / Codecov" "Failed to publish unittest results."
-          else
-            printf "Codecov: No errors to report.\n"
-          fi
-
       - name: 📤 Upload merged 'JUnit Test Summary' artifact
         uses: pyTooling/upload-artifact@v4
         if: inputs.merged_junit_artifact != ''
@@ -157,3 +151,24 @@ jobs:
           if-no-files-found: error
           retention-days: 1
           investigate: true
+
+      - name: Generate error messages
+        run: |
+          exitCode=0
+          if [[ "${{ steps.test-reporter.outcome }}" == "failure" ]]; then
+            printf "❌ Dorney/Test-Reporter: %s\n" "Failed to publish unittest results."
+            printf "::error title=%s::%s\n" "Dorney/Test-Reporter" "Failed to publish unittest results."
+            exitCode=1
+          else
+            printf "✅ Dorney/Test-Reporter: No errors to report.\n"
+          fi
+
+          if [[ "${{ steps.codecov.outcome }}" == "failure" ]]; then
+            printf "❌ CodeCov: %s\n" "Failed to publish unittest and code coverage results."
+            printf "::error title=%s::%s\n" "CodeCov" "Failed to publish unittest and code coverage results."
+            exitCode=1
+          else
+            printf "✅ CodeCov: No errors to report.\n"
+          fi
+
+          exit $exitCode

--- a/.github/workflows/PublishTestResults.yml
+++ b/.github/workflows/PublishTestResults.yml
@@ -92,10 +92,10 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Download Artifacts
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           pattern: ${{ inputs.unittest_artifacts_pattern }}
           path:    artifacts

--- a/.github/workflows/PublishToGitHubPages.yml
+++ b/.github/workflows/PublishToGitHubPages.yml
@@ -53,23 +53,23 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📥 Download artifacts '${{ inputs.doc }}' from 'SphinxDocumentation' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         with:
           name: ${{ inputs.doc }}
           path: public
 
       - name: 📥 Download artifacts '${{ inputs.coverage }}' from 'Coverage' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         if: ${{ inputs.coverage != '' }}
         with:
           name: ${{ inputs.coverage }}
           path: public/coverage
 
       - name: 📥 Download artifacts '${{ inputs.typing }}' from 'StaticTypeCheck' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         if: ${{ inputs.typing != '' }}
         with:
           name: ${{ inputs.typing }}

--- a/.github/workflows/SphinxDocumentation.yml
+++ b/.github/workflows/SphinxDocumentation.yml
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
           submodules: true
@@ -100,7 +100,7 @@ jobs:
           python -m pip install --disable-pip-version-check ${{ inputs.requirements }}
 
       - name: 📥 Download artifacts '${{ inputs.unittest_xml_artifact }}' from 'Unittesting' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         if: inputs.unittest_xml_artifact != ''
         with:
           name: ${{ inputs.unittest_xml_artifact }}
@@ -108,7 +108,7 @@ jobs:
           investigate: true
 
       - name: 📥 Download artifacts '${{ inputs.coverage_json_artifact }}' from 'PublishCoverageResults' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         if: inputs.coverage_json_artifact != ''
         with:
           name: ${{ inputs.coverage_json_artifact }}
@@ -140,7 +140,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
           submodules: true
@@ -159,7 +159,7 @@ jobs:
           python -m pip install --disable-pip-version-check ${{ inputs.requirements }}
 
       - name: 📥 Download artifacts '${{ inputs.unittest_xml_artifact }}' from 'Unittesting' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         if: inputs.unittest_xml_artifact != ''
         with:
           name: ${{ inputs.unittest_xml_artifact }}
@@ -167,7 +167,7 @@ jobs:
           investigate: true
 
       - name: 📥 Download artifacts '${{ inputs.coverage_json_artifact }}' from 'PublishCoverageResults' job
-        uses: pyTooling/download-artifact@v4
+        uses: pyTooling/download-artifact@v5
         if: inputs.coverage_json_artifact != ''
         with:
           name: ${{ inputs.coverage_json_artifact }}

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🐍 Setup Python ${{ inputs.python_version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/TestReleaser.yml
+++ b/.github/workflows/TestReleaser.yml
@@ -3,7 +3,7 @@
 #   Unai Martinez-Corral                                                                                               #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2024 The pyTooling Authors                                                                            #
+# Copyright 2020-2025 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #
@@ -45,7 +45,7 @@ jobs:
     env:
       DOCKER_BUILDKIT: 1
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Build container image
       run: docker build -t ghcr.io/pytooling/releaser -f releaser/Dockerfile releaser
@@ -62,7 +62,7 @@ jobs:
   Composite:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - run: printf "%s\n" "Build some tool and generate some (versioned) artifacts" > artifact-$(date -u +"%Y-%m-%dT%H-%M-%SZ").txt
 
@@ -122,7 +122,7 @@ jobs:
       - Composite
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - run: printf "%s\n" "Build some tool and generate some (versioned) artifacts" > artifact-$(date -u +"%Y-%m-%dT%H-%M-%SZ").txt
 

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -161,7 +161,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
           submodules: true

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -342,6 +342,7 @@ jobs:
 # Run pytests
 
       - name: ✅ Run unit tests (Ubuntu/macOS)
+        id: pytest_bash
         if: matrix.system != 'windows'
         continue-on-error: true
         run: |
@@ -359,6 +360,7 @@ jobs:
           fi
 
       - name: ✅ Run unit tests (Windows)
+        id: pytest_posh
         if: matrix.system == 'windows'
         continue-on-error: true
         run: |
@@ -376,16 +378,19 @@ jobs:
           }
 
       - name: Convert coverage to XML format (Cobertura)
+        id: convert_xml
         if: inputs.coverage_xml_artifact != ''
         continue-on-error: true
         run: coverage xml --data-file=.coverage
 
       - name: Convert coverage to JSON format
+        id: convert_json
         if: inputs.coverage_json_artifact != ''
         continue-on-error: true
         run: coverage json --data-file=.coverage
 
       - name: Convert coverage to HTML format
+        id: convert_html
         if: inputs.coverage_html_artifact != ''
         continue-on-error: true
         run: |
@@ -427,7 +432,7 @@ jobs:
           retention-days: 1
 
       - name: 📤 Upload 'Coverage XML Report' artifact
-        if: inputs.coverage_xml_artifact != ''
+        if: inputs.coverage_xml_artifact != '' && steps.convert_xml.outcome == 'success'
         continue-on-error: true
         uses: pyTooling/upload-artifact@v4
         with:
@@ -437,7 +442,7 @@ jobs:
           retention-days: 1
 
       - name: 📤 Upload 'Coverage JSON Report' artifact
-        if: inputs.coverage_json_artifact != ''
+        if: inputs.coverage_json_artifact != '' && steps.convert_json.outcome == 'success'
         continue-on-error: true
         uses: pyTooling/upload-artifact@v4
         with:
@@ -447,7 +452,7 @@ jobs:
           retention-days: 1
 
       - name: 📤 Upload 'Coverage HTML Report' artifact
-        if: inputs.coverage_html_artifact != ''
+        if: inputs.coverage_html_artifact != '' && steps.convert_html.outcome == 'success'
         continue-on-error: true
         uses: pyTooling/upload-artifact@v4
         with:
@@ -456,3 +461,17 @@ jobs:
           path: '*'
           if-no-files-found: error
           retention-days: 1
+
+      - name: Generate error messages
+        shell: bash
+        run: |
+          exitCode=0
+          if [[ "${{ steps.pytest_bash.outcome }}" == "failure" || "${{ steps.pytest_posh.outcome }}" == "failure" ]]; then
+            printf "❌ pytest: %s\n" "Error in pytest execution."
+            printf "::error title=%s::%s\n" "pytest" "Error in pytest execution."
+            exitCode=1
+          else
+            printf "✅ pytest: No errors.\n"
+          fi
+
+          exit $exitCode

--- a/.github/workflows/VerifyDocs.yml
+++ b/.github/workflows/VerifyDocs.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🐍 Setup Python
         uses: actions/setup-python@v5

--- a/doc/Action/Releaser.rst
+++ b/doc/Action/Releaser.rst
@@ -85,7 +85,7 @@ The following block shows a minimal YAML workflow file:
        steps:
 
        # Clone repository
-       - uses: actions/checkout@v4
+       - uses: actions/checkout@v5
 
        # Build your application, tool, artifacts, etc.
        - name: Build

--- a/releaser/README.md
+++ b/releaser/README.md
@@ -79,7 +79,7 @@ jobs:
     steps:
 
     # Clone repository
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     # Build your application, tool, artifacts, etc.
     - name: Build

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,4 +10,4 @@ pytest-cov ~= 6.2
 # Static Type Checking
 mypy ~= 1.16
 typing_extensions ~= 4.14
-lxml ~= 5.4
+lxml ~= 6.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,13 +1,13 @@
 -r ../requirements.txt
 
 # Coverage collection
-Coverage ~= 7.9
+Coverage ~= 7.10
 
 # Test Runner
 pytest ~= 8.4
 pytest-cov ~= 6.2
 
 # Static Type Checking
-mypy ~= 1.16
+mypy ~= 1.17
 typing_extensions ~= 4.14
 lxml ~= 6.0


### PR DESCRIPTION
# New Features

* Continue in case of testcase errors to upload artifacts and create documentation including test reports with failed entries.  
  Nonetheless, mark the unittest job as failed.
* Continue after testreport failed, because of failed testcases in the summary report. Upload merged testcase results and continue to create the documentation.  
  Nonetheless, mark the publish job as failed.

# Changes

* Bumped dependencies.
  * `actions/checkout@v4` &rarr; `actions/checkout@v5`
  * `pyTooling/download-artifact@v4` &rarr; `pyTooling/download-artifact@v5`
    * `actions/download-artifact@v4` &rarr; `actions/download-artifact@v5`

# Bug Fixes

* Don't run tagging job, when pipeline is a scheduled run.  
  Otherwise, merge-commits on main branch try to retrigger a new release and fail because of existing tag name.
