### PR TITLE
Updating r6 from v6.6.0

### DIFF
--- a/.github/workflows/ApplicationTesting.yml
+++ b/.github/workflows/ApplicationTesting.yml
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: 📥 Download artifacts '${{ inputs.wheel }}' from 'Package' job
-        uses: pyTooling/download-artifact@v5
+        uses: pyTooling/download-artifact@v6
         with:
           name: ${{ inputs.wheel }}
           path: install
@@ -215,9 +215,9 @@ jobs:
         if: matrix.system == 'msys2'
         run: |
           if [ -n '${{ inputs.mingw_requirements }}' ]; then
-            python -m pip install --disable-pip-version-check ${{ inputs.mingw_requirements }}
+            python -m pip install --disable-pip-version-check --break-system-packages ${{ inputs.mingw_requirements }}
           else
-            python -m pip install --disable-pip-version-check ${{ inputs.requirements }}
+            python -m pip install --disable-pip-version-check --break-system-packages ${{ inputs.requirements }}
           fi
 
       - name: 🔧 Install wheel from artifact (Ubuntu/macOS)
@@ -262,7 +262,7 @@ jobs:
 
       - name: 📤 Upload 'TestReportSummary.xml' artifact
         if: inputs.apptest_xml_artifact != ''
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         with:
           name: ${{ inputs.apptest_xml_artifact }}-${{ matrix.system }}-${{ matrix.runtime }}-${{ matrix.python }}
           working-directory: report/unit

--- a/.github/workflows/BuildTheDocs.yml
+++ b/.github/workflows/BuildTheDocs.yml
@@ -49,7 +49,7 @@ jobs:
           skip-deploy: true
 
       - name: 📤 Upload 'documentation' artifacts
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         if: inputs.artifact != ''
         with:
           name: ${{ inputs.artifact }}

--- a/.github/workflows/CompletePipeline.yml
+++ b/.github/workflows/CompletePipeline.yml
@@ -359,10 +359,10 @@ jobs:
     needs:
       - Prepare
       - UnitTesting
-      - Install
 #      - AppTesting
 #      - StaticTypeCheck
       - Package
+      - Install
       - PublishToGitHubPages
     if: needs.Prepare.outputs.is_release_commit == 'true' && github.event_name != 'schedule'
     permissions:
@@ -378,10 +378,10 @@ jobs:
     needs:
       - Prepare
       - UnitTesting
-      - Install
 #      - AppTesting
 #      - StaticTypeCheck
       - Package
+      - Install
       - PublishToGitHubPages
     if: needs.Prepare.outputs.is_release_tag == 'true'
     permissions:
@@ -418,6 +418,7 @@ jobs:
       - PublishCoverageResults
       - PublishToGitHubPages
 #      - PublishOnPyPI
+      - Install
       - IntermediateCleanUp
     if: inputs.cleanup  == 'true'
     with:

--- a/.github/workflows/CoverageCollection.yml
+++ b/.github/workflows/CoverageCollection.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: 📤 Upload 'Coverage Report' artifact
         continue-on-error: true
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         with:
           name: ${{ inputs.artifact }}
           working-directory: ${{ steps.getVariables.outputs.coverage_report_html_directory }}

--- a/.github/workflows/InstallPackage.yml
+++ b/.github/workflows/InstallPackage.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: 📥 Download artifacts '${{ inputs.wheel }}' from 'Package' job
-        uses: pyTooling/download-artifact@v5
+        uses: pyTooling/download-artifact@v6
         with:
           name: ${{ inputs.wheel }}
           path: install

--- a/.github/workflows/LaTeXDocumentation.yml
+++ b/.github/workflows/LaTeXDocumentation.yml
@@ -60,7 +60,7 @@ jobs:
     continue-on-error: ${{ inputs.can-fail == 'true' }}
     steps:
       - name: 📥 Download artifacts '${{ inputs.latex_artifact }}' from 'SphinxDocumentation' job
-        uses: pyTooling/download-artifact@v5
+        uses: pyTooling/download-artifact@v6
         with:
           name: ${{ inputs.latex_artifact }}
           path: latex
@@ -83,7 +83,7 @@ jobs:
             latexmk -${{ inputs.processor }} "${{ inputs.document }}.tex"
 
       - name: 📤 Upload 'PDF Documentation' artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         if: inputs.pdf_artifact != ''
         with:
           name: ${{ inputs.pdf_artifact }}

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -106,7 +106,7 @@ jobs:
         run: python setup.py bdist_wheel
 
       - name: 📤 Upload wheel artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         with:
           name: ${{ inputs.artifact }}
           working-directory: dist

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -287,8 +287,8 @@ jobs:
           else:
             disabled = [disable.strip() for disable in disable_list.split(" ")]
 
-          if "3.8" in versions:
-            print("::warning title=Deprecated::Support for Python 3.8 ended in 2024.10.")
+          if "3.9" in versions:
+            print("::warning title=Deprecated::Support for Python 3.9 ended in 2025.10.")
           if "msys2" in systems:
             print("::warning title=Deprecated::System 'msys2' will be replaced by 'mingw64'.")
           if currentAlphaVersion in versions:
@@ -300,15 +300,13 @@ jobs:
           data = {
             # Python and PyPy versions supported by "setup-python" action
             "python": {
-              "3.8":       { "icon": "⚫",  "until": "2024.10" },
-              "3.9":       { "icon": "🔴",  "until": "2025.10" },
-              "3.10":      { "icon": "🟠",  "until": "2026.10" },
-              "3.11":      { "icon": "🟡",  "until": "2027.10" },
-              "3.12":      { "icon": "🟢",  "until": "2028.10" },
+              "3.9":       { "icon": "⚫",  "until": "2025.10" },
+              "3.10":      { "icon": "🔴",  "until": "2026.10" },
+              "3.11":      { "icon": "🟠",  "until": "2027.10" },
+              "3.12":      { "icon": "🟡",  "until": "2028.10" },
               "3.13":      { "icon": "🟢",  "until": "2029.10" },
-              "3.14":      { "icon": "🟣",  "until": "2030.10" },
-              "pypy-3.7":  { "icon": "⟲⚫", "until": "????.??" },
-              "pypy-3.8":  { "icon": "⟲⚫", "until": "????.??" },
+              "3.14":      { "icon": "🟢",  "until": "2030.10" },
+              "3.15":      { "icon": "🟣",  "until": "2031.10" },
               "pypy-3.9":  { "icon": "⟲🔴", "until": "????.??" },
               "pypy-3.10": { "icon": "⟲🟠", "until": "????.??" },
               "pypy-3.11": { "icon": "⟲🟡", "until": "????.??" },

--- a/.github/workflows/PublishCoverageResults.yml
+++ b/.github/workflows/PublishCoverageResults.yml
@@ -115,7 +115,7 @@ jobs:
           submodules: true
 
       - name: 📥 Download Artifacts
-        uses: pyTooling/download-artifact@v5
+        uses: pyTooling/download-artifact@v6
         with:
           pattern: ${{ inputs.coverage_artifacts_pattern }}
           path: artifacts
@@ -156,7 +156,7 @@ jobs:
           tree -pash ${{ fromJson(inputs.coverage_report_html).directory }}
 
       - name: 📤 Upload 'Coverage SQLite Database' artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         if: inputs.coverage_sqlite_artifact != ''
         continue-on-error: true
         with:
@@ -166,7 +166,7 @@ jobs:
           retention-days: 1
 
       - name: 📤 Upload 'Coverage XML Report' artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         if: inputs.coverage_xml_artifact != ''
         continue-on-error: true
         with:
@@ -177,7 +177,7 @@ jobs:
           retention-days: 1
 
       - name: 📤 Upload 'Coverage JSON Report' artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         if: inputs.coverage_json_artifact != ''
         continue-on-error: true
         with:
@@ -188,7 +188,7 @@ jobs:
           retention-days: 1
 
       - name: 📤 Upload 'Coverage HTML Report' artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         if: inputs.coverage_html_artifact != ''
         continue-on-error: true
         with:

--- a/.github/workflows/PublishOnPyPI.yml
+++ b/.github/workflows/PublishOnPyPI.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: 📥 Download artifacts '${{ inputs.artifact }}' from 'Package' job
-        uses: pyTooling/download-artifact@v5
+        uses: pyTooling/download-artifact@v6
         with:
           name: ${{ inputs.artifact }}
           path: dist

--- a/.github/workflows/PublishTestResults.yml
+++ b/.github/workflows/PublishTestResults.yml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: 📥 Download Artifacts
-        uses: pyTooling/download-artifact@v5
+        uses: pyTooling/download-artifact@v6
         with:
           pattern: ${{ inputs.unittest_artifacts_pattern }}
           path:    artifacts
@@ -156,7 +156,7 @@ jobs:
           fail_ci_if_error: true
 
       - name: 📤 Upload merged 'JUnit Test Summary' artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         if: inputs.merged_junit_artifact != ''
         with:
           name: ${{ inputs.merged_junit_artifact }}

--- a/.github/workflows/PublishToGitHubPages.yml
+++ b/.github/workflows/PublishToGitHubPages.yml
@@ -56,20 +56,20 @@ jobs:
         uses: actions/checkout@v5
 
       - name: 📥 Download artifacts '${{ inputs.doc }}' from 'SphinxDocumentation' job
-        uses: pyTooling/download-artifact@v5
+        uses: pyTooling/download-artifact@v6
         with:
           name: ${{ inputs.doc }}
           path: public
 
       - name: 📥 Download artifacts '${{ inputs.coverage }}' from 'Coverage' job
-        uses: pyTooling/download-artifact@v5
+        uses: pyTooling/download-artifact@v6
         if: ${{ inputs.coverage != '' }}
         with:
           name: ${{ inputs.coverage }}
           path: public/coverage
 
       - name: 📥 Download artifacts '${{ inputs.typing }}' from 'StaticTypeCheck' job
-        uses: pyTooling/download-artifact@v5
+        uses: pyTooling/download-artifact@v6
         if: ${{ inputs.typing != '' }}
         with:
           name: ${{ inputs.typing }}

--- a/.github/workflows/SphinxDocumentation.yml
+++ b/.github/workflows/SphinxDocumentation.yml
@@ -105,7 +105,7 @@ jobs:
           python -m pip install --disable-pip-version-check ${{ inputs.requirements }}
 
       - name: 📥 Download artifacts '${{ inputs.unittest_xml_artifact }}' from 'Unittesting' job
-        uses: pyTooling/download-artifact@v5
+        uses: pyTooling/download-artifact@v6
         if: inputs.unittest_xml_artifact != ''
         with:
           name: ${{ inputs.unittest_xml_artifact }}
@@ -113,7 +113,7 @@ jobs:
           investigate: true
 
       - name: 📥 Download artifacts '${{ inputs.coverage_json_artifact }}' from 'PublishCoverageResults' job
-        uses: pyTooling/download-artifact@v5
+        uses: pyTooling/download-artifact@v6
         if: inputs.coverage_json_artifact != ''
         with:
           name: ${{ inputs.coverage_json_artifact }}
@@ -129,7 +129,7 @@ jobs:
           sphinx-build -v -n -b html -d _build/doctrees -j $(nproc) -w _build/html.log . _build/html
 
       - name: 📤 Upload 'HTML Documentation' artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         if: inputs.html_artifact != ''
         continue-on-error: true
         with:
@@ -164,7 +164,7 @@ jobs:
           python -m pip install --disable-pip-version-check ${{ inputs.requirements }}
 
       - name: 📥 Download artifacts '${{ inputs.unittest_xml_artifact }}' from 'Unittesting' job
-        uses: pyTooling/download-artifact@v5
+        uses: pyTooling/download-artifact@v6
         if: inputs.unittest_xml_artifact != ''
         with:
           name: ${{ inputs.unittest_xml_artifact }}
@@ -172,7 +172,7 @@ jobs:
           investigate: true
 
       - name: 📥 Download artifacts '${{ inputs.coverage_json_artifact }}' from 'PublishCoverageResults' job
-        uses: pyTooling/download-artifact@v5
+        uses: pyTooling/download-artifact@v6
         if: inputs.coverage_json_artifact != ''
         with:
           name: ${{ inputs.coverage_json_artifact }}
@@ -272,7 +272,7 @@ jobs:
           done
 
       - name: 📤 Upload 'LaTeX Documentation' artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         if: inputs.latex_artifact != ''
         continue-on-error: true
         with:

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -142,7 +142,7 @@ jobs:
           fi
 
       - name: 📤 Upload '${{ inputs.html_artifact }}' HTML artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         if: ${{ inputs.html_artifact != '' }}
         continue-on-error: true
         with:
@@ -153,7 +153,7 @@ jobs:
           retention-days: 1
 
       - name: 📤 Upload '${{ inputs.junit_artifact }}' JUnit artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         if: ${{ inputs.junit_artifact != '' }}
         continue-on-error: true
         with:
@@ -164,7 +164,7 @@ jobs:
           retention-days: 1
 
       - name: 📤 Upload '${{ inputs.cobertura_artifact }}' Cobertura artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         if: ${{ inputs.cobertura_artifact != '' }}
         continue-on-error: true
         with:

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -203,7 +203,7 @@ jobs:
         if: matrix.system == 'msys2'
         shell: pwsh
         run: |
-          py -3.9 -m pip install --disable-pip-version-check -U tomli
+          py -3.9 -m pip install --disable-pip-version-check --break-system-packages -U tomli
 
       - name: Compute pacman/pacboy packages
         id: pacboy
@@ -330,9 +330,9 @@ jobs:
         if: matrix.system == 'msys2'
         run: |
           if [ -n '${{ inputs.mingw_requirements }}' ]; then
-            python -m pip install --disable-pip-version-check ${{ inputs.mingw_requirements }}
+            python -m pip install --disable-pip-version-check --break-system-packages ${{ inputs.mingw_requirements }}
           else
-            python -m pip install --disable-pip-version-check ${{ inputs.requirements }}
+            python -m pip install --disable-pip-version-check --break-system-packages ${{ inputs.requirements }}
           fi
 
 # Before scripts
@@ -421,7 +421,7 @@ jobs:
 # Upload artifacts
 
       - name: 📤 Upload '${{ fromJson(inputs.unittest_report_xml).filename }}' artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         if: inputs.unittest_xml_artifact != ''
         continue-on-error: true
         with:
@@ -434,7 +434,7 @@ jobs:
 #      - name: 📤 Upload 'Unit Tests HTML Report' artifact
 #        if: inputs.unittest_html_artifact != ''
 #        continue-on-error: true
-#        uses: pyTooling/upload-artifact@v4
+#        uses: pyTooling/upload-artifact@v5
 #        with:
 #          name: ${{ inputs.unittest_html_artifact }}-${{ matrix.system }}-${{ matrix.runtime }}-${{ matrix.python }}
 #          path: ${{ inputs.unittest_report_html_directory }}
@@ -444,7 +444,7 @@ jobs:
       - name: 📤 Upload 'Coverage SQLite Database' artifact
         if: inputs.coverage_sqlite_artifact != ''
         continue-on-error: true
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         with:
           name: ${{ inputs.coverage_sqlite_artifact }}-${{ matrix.system }}-${{ matrix.runtime }}-${{ matrix.python }}
           path: .coverage
@@ -455,7 +455,7 @@ jobs:
       - name: 📤 Upload 'Coverage XML Report' artifact
         if: inputs.coverage_xml_artifact != '' && steps.convert_xml.outcome == 'success'
         continue-on-error: true
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         with:
           name: ${{ inputs.coverage_xml_artifact }}-${{ matrix.system }}-${{ matrix.runtime }}-${{ matrix.python }}
           working-directory: ${{ fromJson(inputs.coverage_report_xml).directory }}
@@ -466,7 +466,7 @@ jobs:
       - name: 📤 Upload 'Coverage JSON Report' artifact
         if: inputs.coverage_json_artifact != '' && steps.convert_json.outcome == 'success'
         continue-on-error: true
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         with:
           name: ${{ inputs.coverage_json_artifact }}-${{ matrix.system }}-${{ matrix.runtime }}-${{ matrix.python }}
           working-directory: ${{ fromJson(inputs.coverage_report_json).directory }}
@@ -477,7 +477,7 @@ jobs:
       - name: 📤 Upload 'Coverage HTML Report' artifact
         if: inputs.coverage_html_artifact != '' && steps.convert_html.outcome == 'success'
         continue-on-error: true
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         with:
           name: ${{ inputs.coverage_html_artifact }}-${{ matrix.system }}-${{ matrix.runtime }}-${{ matrix.python }}
           working-directory: ${{ fromJson(inputs.coverage_report_html).directory }}

--- a/.github/workflows/_Checking_ArtifactCleanup.yml
+++ b/.github/workflows/_Checking_ArtifactCleanup.yml
@@ -25,7 +25,7 @@ jobs:
         run: printf "%s\n" "${{ matrix.runs-on }}-${{ matrix.python }}" >> artifact.txt
 
       - name: 📤 Upload artifact for ${{ matrix.system }}-${{ matrix.python }}
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         with:
           name: ${{ fromJson(needs.Params.outputs.artifact_names).unittesting_xml }}-${{ matrix.system }}-${{ matrix.python }}
           path: artifact.txt
@@ -42,7 +42,7 @@ jobs:
         run: printf "%s\n" "Package" >> package.txt
 
       - name: 📤 Upload artifact for ${{ matrix.system }}-${{ matrix.python }}
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         with:
           name: ${{ fromJson(needs.Params.outputs.artifact_names).package_all }}
           path: package.txt

--- a/.github/workflows/_Checking_JobTemplates.yml
+++ b/.github/workflows/_Checking_JobTemplates.yml
@@ -221,9 +221,9 @@ jobs:
       - Prepare
       - UnitTesting
       - PlatformTesting
-      - Install
 #      - StaticTypeCheck
       - Package
+      - Install
       - PublishToGitHubPages
     permissions:
       contents: write  # required for create tag
@@ -239,9 +239,9 @@ jobs:
       - Prepare
       - UnitTesting
       - PlatformTesting
-      - Install
 #      - StaticTypeCheck
       - Package
+      - Install
       - PublishToGitHubPages
     if: needs.Prepare.outputs.is_release_tag == 'true'
     permissions:
@@ -277,6 +277,7 @@ jobs:
       - PublishTestResults
       - PublishCoverageResults
       - PublishToGitHubPages
+      - Install
       - IntermediateCleanUp
     with:
       package: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).package_all }}

--- a/.github/workflows/_Checking_Nightly.yml
+++ b/.github/workflows/_Checking_Nightly.yml
@@ -17,7 +17,7 @@ jobs:
           printf "%s\n" "Build log $(date --utc '+%d.%m.%Y - %H:%M:%S')"    > build.log
 
       - name: 📤 Upload artifact
-        uses: pyTooling/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v5
         with:
           name: document
           path: |
@@ -32,7 +32,7 @@ jobs:
           printf "%s\n" "Program $(date --utc '+%d.%m.%Y - %H:%M:%S')"        > program.py
 
       - name: 📤 Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: other
           path: |

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,5 +15,5 @@ sphinxcontrib-mermaid ~= 1.0
 autoapi >= 2.0.1
 sphinx_design ~= 0.6
 sphinx-copybutton >= 0.5
-sphinx_autodoc_typehints ~= 3.2
+sphinx_autodoc_typehints ~= 3.5
 sphinx_reports ~= 0.9

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,4 +10,4 @@ pytest-cov ~= 7.0
 # Static Type Checking
 mypy[reports] ~= 1.18
 typing_extensions ~= 4.15
-lxml ~= 6.0
+lxml >= 5.4, <7.0


### PR DESCRIPTION
# New Features

* Removed Python 3.8 support.

# Changes

* Updated upload-artifact to @v5.
* Updated download-artifact to @v6.
* Added pip parameter '--break-system-packages'.
* Relaxed required `lxml` version.

# Bug Fixes

* Fixed colors of icons representing Python versions.

# Unit Tests

* Fixed dependencies of `ArtifactCleanUp` in `CompletePipeline`.

----------
# Related Issues and Pull-Requests

* #171