### PR TITLE
Updating r7 from v7.2.1

### DIFF
--- a/.github/workflows/ApplicationTesting.yml
+++ b/.github/workflows/ApplicationTesting.yml
@@ -4,7 +4,7 @@
 #   Unai Martinez-Corral                                                                                               #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/ArtifactCleanUp.yml
+++ b/.github/workflows/ArtifactCleanUp.yml
@@ -4,7 +4,7 @@
 #   Unai Martinez-Corral                                                                                               #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/CheckCodeQuality.yml
+++ b/.github/workflows/CheckCodeQuality.yml
@@ -3,7 +3,7 @@
 #   Patrick Lehmann                                                                                                    #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2025-2025 The pyTooling Authors                                                                            #
+# Copyright 2025-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/CheckDocumentation.yml
+++ b/.github/workflows/CheckDocumentation.yml
@@ -3,7 +3,7 @@
 #   Patrick Lehmann                                                                                                    #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/CompletePipeline.yml
+++ b/.github/workflows/CompletePipeline.yml
@@ -3,7 +3,7 @@
 #   Patrick Lehmann                                                                                                    #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/ExtractConfiguration.yml
+++ b/.github/workflows/ExtractConfiguration.yml
@@ -3,7 +3,7 @@
 #   Patrick Lehmann                                                                                                    #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/InstallPackage.yml
+++ b/.github/workflows/InstallPackage.yml
@@ -3,7 +3,7 @@
 #   Patrick Lehmann                                                                                                    #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2025-2025 The pyTooling Authors                                                                            #
+# Copyright 2025-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/IntermediateCleanUp.yml
+++ b/.github/workflows/IntermediateCleanUp.yml
@@ -3,7 +3,7 @@
 #   Patrick Lehmann                                                                                                    #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/LaTeXDocumentation.yml
+++ b/.github/workflows/LaTeXDocumentation.yml
@@ -3,7 +3,7 @@
 #   Patrick Lehmann                                                                                                    #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -4,7 +4,7 @@
 #   Unai Martinez-Corral                                                                                               #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -4,7 +4,7 @@
 #   Unai Martinez-Corral                                                                                               #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/PrepareJob.yml
+++ b/.github/workflows/PrepareJob.yml
@@ -1,3 +1,24 @@
+# ==================================================================================================================== #
+# Authors:                                                                                                             #
+#   Patrick Lehmann                                                                                                    #
+#                                                                                                                      #
+# ==================================================================================================================== #
+# Copyright 2025-2026 The pyTooling Authors                                                                            #
+#                                                                                                                      #
+# Licensed under the Apache License, Version 2.0 (the "License");                                                      #
+# you may not use this file except in compliance with the License.                                                     #
+# You may obtain a copy of the License at                                                                              #
+#                                                                                                                      #
+#   http://www.apache.org/licenses/LICENSE-2.0                                                                         #
+#                                                                                                                      #
+# Unless required by applicable law or agreed to in writing, software                                                  #
+# distributed under the License is distributed on an "AS IS" BASIS,                                                    #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.                                             #
+# See the License for the specific language governing permissions and                                                  #
+# limitations under the License.                                                                                       #
+#                                                                                                                      #
+# SPDX-License-Identifier: Apache-2.0                                                                                  #
+# ==================================================================================================================== #
 name: Prepare Variables
 
 on:

--- a/.github/workflows/PublishCoverageResults.yml
+++ b/.github/workflows/PublishCoverageResults.yml
@@ -3,7 +3,7 @@
 #   Patrick Lehmann                                                                                                    #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/PublishOnPyPI.yml
+++ b/.github/workflows/PublishOnPyPI.yml
@@ -4,7 +4,7 @@
 #   Unai Martinez-Corral                                                                                               #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/PublishReleaseNotes.yml
+++ b/.github/workflows/PublishReleaseNotes.yml
@@ -3,7 +3,7 @@
 #   Patrick Lehmann                                                                                                    #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #
@@ -880,11 +880,11 @@ jobs:
 
           export GH_TOKEN=${{ github.token }}
 
-          if [[ -s __ASSETS__.md ]]; then
-            addNotes=("--notes-file" "__ASSETS__.md")
+          if [[ -s __NOTES__.md ]]; then
+            addNotes=("--notes-file" "__NOTES__.md")
           else
-            printf "  ${ANSI_LIGHT_RED}File '%s' not found.${ANSI_NOCOLOR}\n" "__ASSETS__.md"
-            printf "::error title=%s::%s\n" "InternalError" "File '__ASSETS__.md' not found."
+            printf "  ${ANSI_LIGHT_RED}File '%s' not found.${ANSI_NOCOLOR}\n" "__NOTES__.md"
+            printf "::error title=%s::%s\n" "InternalError" "File '__NOTES__.md' not found."
             exit 1
           fi
 

--- a/.github/workflows/PublishTestResults.yml
+++ b/.github/workflows/PublishTestResults.yml
@@ -4,7 +4,7 @@
 #   Unai Martinez-Corral                                                                                               #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/PublishToGitHubPages.yml
+++ b/.github/workflows/PublishToGitHubPages.yml
@@ -4,7 +4,7 @@
 #   Unai Martinez-Corral                                                                                               #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/SphinxDocumentation.yml
+++ b/.github/workflows/SphinxDocumentation.yml
@@ -3,7 +3,7 @@
 #   Patrick Lehmann                                                                                                    #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -4,7 +4,7 @@
 #   Unai Martinez-Corral                                                                                               #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/TagReleaseCommit.yml
+++ b/.github/workflows/TagReleaseCommit.yml
@@ -4,7 +4,7 @@
 #   Unai Martinez-Corral                                                                                               #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -4,7 +4,7 @@
 #   Unai Martinez-Corral                                                                                               #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/.github/workflows/VerifyDocs.yml
+++ b/.github/workflows/VerifyDocs.yml
@@ -4,7 +4,7 @@
 #   Unai Martinez-Corral                                                                                               #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/dist/requirements.txt
+++ b/dist/requirements.txt
@@ -1,2 +1,2 @@
-wheel ~= 0.45
+wheel ~= 0.45.0
 twine ~= 6.2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,7 +4,7 @@ pyTooling ~= 8.8
 
 # Enforce latest version on ReadTheDocs
 sphinx ~= 8.2
-docutils ~= 0.21
+docutils ~= 0.21.0
 docutils_stubs ~= 0.0.22
 
 # ReadTheDocs Theme
@@ -13,7 +13,7 @@ sphinx_rtd_theme ~= 3.0
 # Sphinx Extenstions
 sphinxcontrib-mermaid ~= 1.2
 autoapi >= 2.0.1
-sphinx_design ~= 0.6
-sphinx-copybutton >= 0.5
+sphinx_design ~= 0.6.0
+sphinx-copybutton >= 0.5.0
 sphinx_autodoc_typehints ~= 3.5   # 3.6 is conflicting with old sphinx_design and rtd theme due to sphinx<9 and docutils<0.22
-sphinx_reports ~= 0.9
+sphinx_reports ~= 0.9.0

--- a/myFramework/Extension/__init__.py
+++ b/myFramework/Extension/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2017-2025 Patrick Lehmann - Bötzingen, Germany                                                             #
+# Copyright 2017-2026 Patrick Lehmann - Bötzingen, Germany                                                             #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #
@@ -34,7 +34,7 @@ A module for a set of dummy classes.
 
 __author__ =        "Patrick Lehmann"
 __email__ =         "Paebbels@gmail.com"
-__copyright__ =     "2017-2025, Patrick Lehmann"
+__copyright__ =     "2017-2026, Patrick Lehmann"
 __license__ =       "Apache License, Version 2.0"
 __version__ =       "0.14.8"
 __keywords__ =      ["GitHub Actions"]

--- a/myPackage/__init__.py
+++ b/myPackage/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2017-2025 Patrick Lehmann - Bötzingen, Germany                                                             #
+# Copyright 2017-2026 Patrick Lehmann - Bötzingen, Germany                                                             #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #
@@ -34,9 +34,9 @@ A module for a set of dummy classes.
 
 __author__ =        "Patrick Lehmann"
 __email__ =         "Paebbels@gmail.com"
-__copyright__ =     "2017-2025, Patrick Lehmann"
+__copyright__ =     "2017-2026, Patrick Lehmann"
 __license__ =       "Apache License, Version 2.0"
-__version__ =       "7.2.0"
+__version__ =       "7.2.1"
 __keywords__ =      ["GitHub Actions"]
 __issue_tracker__ = "https://GitHub.com/pyTooling/Actions/issues"
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2017-2025 Patrick Lehmann - Bötzingen, Germany                                                             #
+# Copyright 2017-2026 Patrick Lehmann - Bötzingen, Germany                                                             #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/platform/Specific.py
+++ b/tests/platform/Specific.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2017-2025 Patrick Lehmann - Bötzingen, Germany                                                             #
+# Copyright 2017-2026 Patrick Lehmann - Bötzingen, Germany                                                             #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/AppInit.py
+++ b/tests/unit/AppInit.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2017-2025 Patrick Lehmann - Bötzingen, Germany                                                             #
+# Copyright 2017-2026 Patrick Lehmann - Bötzingen, Germany                                                             #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -11,7 +11,7 @@
 #                                                                                                                      #
 # License:                                                                                                             #
 # ==================================================================================================================== #
-# Copyright 2017-2025 Patrick Lehmann - Bötzingen, Germany                                                             #
+# Copyright 2017-2026 Patrick Lehmann - Bötzingen, Germany                                                             #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #

--- a/with-post-step/action.yml
+++ b/with-post-step/action.yml
@@ -4,7 +4,7 @@
 #   Unai Martinez-Corral                                                                                               #
 #                                                                                                                      #
 # ==================================================================================================================== #
-# Copyright 2020-2025 The pyTooling Authors                                                                            #
+# Copyright 2020-2026 The pyTooling Authors                                                                            #
 #                                                                                                                      #
 # Licensed under the Apache License, Version 2.0 (the "License");                                                      #
 # you may not use this file except in compliance with the License.                                                     #


### PR DESCRIPTION
# Changes

* Bumped copyright information.
* `PrepareJob`:
  * Added missing file header.

# Bug Fixes

* `PublishReleaseNotes`:
  * Upload the correct file `__NOTES__.md` as release notes.
* Fixed required Python package versions for `v0.X` packages to `v0.X.0`.  
  This enables correct usage of the `~=` operator.

----------
# Related Issues and Pull-Requests

* #187 
