### PR TITLE
Updating r7 from v7.3.0

### DIFF
--- a/.github/workflows/ApplicationTesting.yml
+++ b/.github/workflows/ApplicationTesting.yml
@@ -146,7 +146,7 @@ jobs:
             "pyyaml":              "python-pyyaml:p python-types-pyyaml:p",
             "ruamel.yaml":         "python-ruamel-yaml:p python-ruamel.yaml.clib:p",
             "sphinx":              "python-markupsafe:p",
-            "tomli":               "python-tomli:p",
+            "tomli":               "python-tomli:p",        # outdated, now part of Python as tomllib
             "wheel":               "python-wheel:p",
             "pyEDAA.ProjectModel": "python-ruamel-yaml:p python-ruamel.yaml.clib:p python-lxml:p",
             "pyEDAA.Reports":      "python-ruamel-yaml:p python-ruamel.yaml.clib:p python-lxml:p",

--- a/.github/workflows/ExtractConfiguration.yml
+++ b/.github/workflows/ExtractConfiguration.yml
@@ -89,9 +89,9 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
-      - name: 🔧 Install wheel,tomli and pip dependencies (native)
+      - name: 🔧 Install wheel and pip dependencies (native)
         run: |
-          python -m pip install --disable-pip-version-check -U wheel tomli
+          python -m pip install --disable-pip-version-check -U wheel
 
       - name: 🔁 Extract configurations from pyproject.toml
         id: getVariables
@@ -105,7 +105,7 @@ jobs:
 
           print(f"Python: {version} (of default installation)")
 
-          from tomli import load as tomli_load
+          from tomllib import load as toml_load
 
           unittestXMLFile =       Path("./unittest.xml")
           coverageHTMLDirectory = Path("htmlcov")
@@ -121,7 +121,7 @@ jobs:
             pyProjectFile =  Path("pyproject.toml")
             if pyProjectFile.exists():
               with pyProjectFile.open("rb") as file:
-                pyProjectSettings = tomli_load(file)
+                pyProjectSettings = toml_load(file)
 
               toolSection = pyProjectSettings["tool"]
               if "pytest" in toolSection:
@@ -163,7 +163,7 @@ jobs:
             coverageRCFile = Path(coverageRC)
             if coverageRCFile.exists():
               with coverageRCFile.open("rb") as file:
-                coverageRCSettings = tomli_load(file)
+                coverageRCSettings = toml_load(file)
 
               coverageHTMLDirectory = Path(coverageRCSettings["html"]["directory"])
               coverageXMLFile =       Path(coverageRCSettings["xml"]["output"])

--- a/.github/workflows/InstallPackage.yml
+++ b/.github/workflows/InstallPackage.yml
@@ -70,7 +70,6 @@ jobs:
             python-markupsafe:p
             python-pyaml:p python-types-pyyaml:p
             python-ruamel-yaml:p python-ruamel.yaml.clib:p
-            python-tomli:p
 
       - name: 🐍 Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v6

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -287,9 +287,9 @@ jobs:
           exclude_list =   "${{ inputs.exclude_list }}".strip()
           disable_list =   "${{ inputs.disable_list }}".strip()
 
-          currentMSYS2Version = "3.12"
+          currentMSYS2Version = "3.13"
           currentAlphaVersion = "3.15"
-          currentAlphaRelease = "3.15.0-a.1"
+          currentAlphaRelease = "3.15.0-a.4"
 
           if systems == "":
             print("::error title=Parameters::system_list is empty.")

--- a/.github/workflows/PublishCoverageResults.yml
+++ b/.github/workflows/PublishCoverageResults.yml
@@ -124,9 +124,9 @@ jobs:
         run: |
           tree -pash artifacts
 
-      - name: 🔧 Install coverage and tomli
+      - name: 🔧 Install coverage
         run: |
-          python -m pip install -U --disable-pip-version-check --break-system-packages coverage[toml] tomli
+          python -m pip install -U --disable-pip-version-check --break-system-packages coverage[toml]
 
       - name: Rename .coverage files and move them all into 'coverage/'
         run: |

--- a/.github/workflows/SphinxDocumentation.yml
+++ b/.github/workflows/SphinxDocumentation.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
-      - name: 🔧 Install wheel,tomli and pip dependencies (native)
+      - name: 🔧 Install wheel and pip dependencies (native)
         run: |
           python -m pip install --disable-pip-version-check -U wheel
           python -m pip install --disable-pip-version-check ${{ inputs.requirements }}
@@ -158,7 +158,7 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
-      - name: 🔧 Install wheel,tomli and pip dependencies (native)
+      - name: 🔧 Install wheel and pip dependencies (native)
         run: |
           python -m pip install --disable-pip-version-check -U wheel
           python -m pip install --disable-pip-version-check ${{ inputs.requirements }}

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -199,11 +199,11 @@ jobs:
 
 # Compute Dependencies for MSYS2 steps
 
-      - name: 🔧 Install dependencies (system Python for Python shell)
-        if: matrix.system == 'msys2'
-        shell: pwsh
-        run: |
-          py -3.9 -m pip install --disable-pip-version-check --break-system-packages -U tomli
+#      - name: 🔧 Install dependencies (system Python for Python shell)
+#        if: matrix.system == 'msys2'
+#        shell: pwsh
+#        run: |
+#          py -3.12 -m pip install --disable-pip-version-check --break-system-packages -U tomli
 
       - name: Compute path to requirements file
         id: requirements
@@ -286,7 +286,7 @@ jobs:
             "ruamel.yaml":         "python-ruamel-yaml:p",
           #  "ruamel.yaml":         "python-ruamel-yaml:p python-ruamel.yaml.clib:p",
             "sphinx":              "python-markupsafe:p",
-            "tomli":               "python-tomli:p",
+            "tomli":               "python-tomli:p",        # outdated, now part of Python as tomllib
             "wheel":               "python-wheel:p",
             "pyedaa.projectmodel": "python-ruamel-yaml:p python-ruamel.yaml.clib:p python-lxml:p",
             "pyedaa.reports":      "python-ruamel-yaml:p python-ruamel.yaml.clib:p python-lxml:p",
@@ -351,10 +351,10 @@ jobs:
 
 # Python Dependency steps
 
-      - name: 🔧 Install wheel,tomli and pip dependencies (native)
+      - name: 🔧 Install wheel and pip dependencies (native)
         if: matrix.system != 'msys2'
         run: |
-          python -m pip install --disable-pip-version-check -U wheel tomli
+          python -m pip install --disable-pip-version-check -U wheel
           python -m pip install --disable-pip-version-check ${{ steps.requirements.outputs.requirements }}
 
       - name: 🔧 Install pip dependencies (MSYS2)

--- a/.github/workflows/_Checking_Parameters.yml
+++ b/.github/workflows/_Checking_Parameters.yml
@@ -73,7 +73,7 @@ jobs:
           expected-python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
           expected-systems:         '["ubuntu", "ubuntu-arm", "windows", "windows-arm", "macos", "macos-arm"]'
           expected-exclude-jobs:    '["windows-arm:3.10"]'
-          expected-include-jobs:    '["mingw64:3.12", "ucrt64:3.12"]'
+          expected-include-jobs:    '["mingw64:3.13", "ucrt64:3.13"]'
           generated-default-version: ${{ needs.Params_Default.outputs.python_version }}
           generated-jobmatrix:       ${{ needs.Params_Default.outputs.python_jobs }}
 
@@ -101,7 +101,7 @@ jobs:
           expected-python-versions: '["3.12", "3.13", "pypy-3.10", "pypy-3.11"]'
           expected-systems:         '["ubuntu", "ubuntu-arm", "windows", "windows-arm", "macos", "macos-arm"]'
           expected-exclude-jobs:    '["windows-arm:pypy-3.10", "windows-arm:pypy-3.11"]'
-          expected-include-jobs:    '["mingw64:3.12", "ucrt64:3.12"]'
+          expected-include-jobs:    '["mingw64:3.13", "ucrt64:3.13"]'
           generated-default-version: ${{ needs.Params_PythonVersions.outputs.python_version }}
           generated-jobmatrix:       ${{ needs.Params_PythonVersions.outputs.python_jobs }}
 
@@ -123,7 +123,7 @@ jobs:
           expected-python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
           expected-systems:         '["windows"]'
           expected-exclude-jobs:    '[]'
-          expected-include-jobs:    '["mingw32:3.12", "mingw64:3.12"]'
+          expected-include-jobs:    '["mingw32:3.13", "mingw64:3.13"]'
           generated-default-version: ${{ needs.Params_Systems.outputs.python_version }}
           generated-jobmatrix:       ${{ needs.Params_Systems.outputs.python_jobs }}
 

--- a/doc/JobTemplate/AllInOne/CompletePipeline.rst
+++ b/doc/JobTemplate/AllInOne/CompletePipeline.rst
@@ -124,7 +124,6 @@ It can be used for simple Python packages as well as namespace packages.
               * :gh:`actions/setup-python`
 
                 * :pypi:`wheel`
-                * :pypi:`tomli`
 
             * :ref:`pyTooling/Actions/.github/workflows/UnitTesting.yml <JOBTMPL/UnitTesting>`
 
@@ -145,7 +144,6 @@ It can be used for simple Python packages as well as namespace packages.
               * pip
 
                 * :pypi:`wheel`
-                * :pypi:`tomli`
                 * Python packages specified via :ref:`JOBTMPL/UnitTesting/Input/requirements` or
                   :ref:`JOBTMPL/UnitTesting/Input/mingw_requirements` parameter.
 
@@ -203,7 +201,6 @@ It can be used for simple Python packages as well as namespace packages.
               * pip
 
                 * :pypi:`coverage`
-                * :pypi:`tomli`
 
               * :gh:`pyTooling/upload-artifact`
 

--- a/doc/JobTemplate/Publish/PublishCoverageResults.rst
+++ b/doc/JobTemplate/Publish/PublishCoverageResults.rst
@@ -56,7 +56,6 @@ cloud services like :term:`CodeCov` or :term:`Codacy`.
    * pip
 
      * :pypi:`coverage`
-     * :pypi:`tomli`
 
    * :gh:`pyTooling/upload-artifact`
 

--- a/doc/JobTemplate/Setup/ExtractConfiguration.rst
+++ b/doc/JobTemplate/Setup/ExtractConfiguration.rst
@@ -49,7 +49,6 @@ duplications within jobs.
    * :gh:`actions/setup-python`
 
      * :pypi:`wheel`
-     * :pypi:`tomli`
 
 
 .. _JOBTMPL/ExtractConfiguration/Instantiation:

--- a/doc/JobTemplate/Testing/UnitTesting.rst
+++ b/doc/JobTemplate/Testing/UnitTesting.rst
@@ -60,7 +60,6 @@ Configuration options to :term:`pytest` should be given via section ``[tool.pyte
    * pip
 
      * :pypi:`wheel`
-     * :pypi:`tomli`
      * Python packages specified via :ref:`JOBTMPL/UnitTesting/Input/requirements` or
        :ref:`JOBTMPL/UnitTesting/Input/mingw_requirements` parameter.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -164,7 +164,7 @@ Example Pipelines
             .. code-block:: toml
 
                [build-system]
-               requires = ["setuptools >= 80.0", "wheel ~= 0.45", "pyTooling ~= 8.8"]
+               requires = ["setuptools >= 80.0", "wheel ~= 0.45.0", "pyTooling ~= 8.10"]
                build-backend = "setuptools.build_meta"
 
                [tool.mypy]

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 -r ../requirements.txt
 
-pyTooling ~= 8.8
+pyTooling ~= 8.10
 
 # Enforce latest version on ReadTheDocs
 sphinx ~= 8.2

--- a/myPackage/__init__.py
+++ b/myPackage/__init__.py
@@ -36,7 +36,7 @@ __author__ =        "Patrick Lehmann"
 __email__ =         "Paebbels@gmail.com"
 __copyright__ =     "2017-2026, Patrick Lehmann"
 __license__ =       "Apache License, Version 2.0"
-__version__ =       "7.2.1"
+__version__ =       "7.3.0"
 __keywords__ =      ["GitHub Actions"]
 __issue_tracker__ = "https://GitHub.com/pyTooling/Actions/issues"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
   "setuptools >= 80.0",
-  "wheel ~= 0.45",
-  "pyTooling ~= 8.8"
+  "wheel ~= 0.45.0",
+  "pyTooling ~= 8.10"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyTooling ~= 8.8
+pyTooling ~= 8.10

--- a/run.ps1
+++ b/run.ps1
@@ -116,7 +116,9 @@ $jobs = @()
 if ($livedoc)
 { Write-Host -ForegroundColor DarkYellow    "[live][DOC]       Building documentation using Sphinx ..."
 
-  .\doc\make.bat html --verbose
+  cd doc
+  py -3.14 -m sphinx.cmd.build -b html . _build/html --doctree-dir _build/doctrees --jobs auto --warning-file _build/sphinx-warnings.log --verbose
+  cd ..
 
   Write-Host -ForegroundColor DarkYellow    "[live][DOC]       Documentation finished"
 }
@@ -126,7 +128,8 @@ elseif ($doc)
 
   # Compile documentation
   $compileDocFunc = {
-    .\doc\make.bat html --verbose
+    cd doc
+    py -3.14 -m sphinx.cmd.build -b html . _build/html --doctree-dir _build/doctrees --jobs auto --warning-file _build/sphinx-warnings.log --verbose
   }
   $docJob = Start-Job -Name "Documentation" -ScriptBlock $compileDocFunc
 #  $jobs += $docJob


### PR DESCRIPTION
# Changes

* Bumped dependencies.
* MSYS2 bumped the Python version from 3.12 to 3.13.
  * Replaced `tomli` by `tomllib`.

# Bug Fixes

* Changed required versions of form `v0.X` to `v0.X.0`, so `~=` operator works correctly.

----------
# Related Issues and Pull-Requests

* #191
