### PR TITLE
Updating r7 from v7.11.0

### DIFF
--- a/.github/workflows/ApplicationTesting.yml
+++ b/.github/workflows/ApplicationTesting.yml
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: 📥 Download artifacts '${{ inputs.wheel }}' from 'Package' job
         uses: pyTooling/download-artifact@v8

--- a/.github/workflows/ArtifactCleanUp.yml
+++ b/.github/workflows/ArtifactCleanUp.yml
@@ -28,7 +28,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       package:
         description: 'Artifacts to be removed on not tagged runs.'

--- a/.github/workflows/CheckCodeQuality.yml
+++ b/.github/workflows/CheckCodeQuality.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
           submodules: true
@@ -140,7 +140,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
           submodules: true
@@ -180,7 +180,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
           submodules: true

--- a/.github/workflows/CheckCodeQuality.yml
+++ b/.github/workflows/CheckCodeQuality.yml
@@ -27,7 +27,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       python_version:
         description: 'Python version.'

--- a/.github/workflows/CheckDocumentation.yml
+++ b/.github/workflows/CheckDocumentation.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: "ubuntu-${{ inputs.ubuntu_image_version }}"
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: 🐍 Setup Python ${{ inputs.python_version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/CheckDocumentation.yml
+++ b/.github/workflows/CheckDocumentation.yml
@@ -27,7 +27,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       python_version:
         description: 'Python version.'

--- a/.github/workflows/CleanupArtifacts.yml
+++ b/.github/workflows/CleanupArtifacts.yml
@@ -27,7 +27,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       json:
         description: 'JSON string of artifact names'

--- a/.github/workflows/CompletePipeline.yml
+++ b/.github/workflows/CompletePipeline.yml
@@ -212,7 +212,7 @@ jobs:
       code_version: ${{ steps.extract.outputs.code_version }}
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # The command 'git describe' (used for version) needs the history.
           fetch-depth: 0

--- a/.github/workflows/CompletePipeline.yml
+++ b/.github/workflows/CompletePipeline.yml
@@ -203,7 +203,7 @@ jobs:
 
   VersionCheck:
     name: ''
-    runs-on: 'ubuntu-24.04'
+    runs-on: 'ubuntu-26.04'
     needs:
       - Prepare
       - UnitTestingParams

--- a/.github/workflows/CompletePipeline.yml
+++ b/.github/workflows/CompletePipeline.yml
@@ -128,6 +128,11 @@ on:
         required: false
         default: 'pytooling/miktex:sphinx'
         type: string
+      miktex_update:
+        description: 'Update MiKTeX packages.'
+        required: false
+        default: 'false'
+        type: string
       auto_tag:
         description: 'Auto tag if a branch was merged to the release branch and an associated pull-request with matching version name was found.'
         required: false
@@ -415,6 +420,7 @@ jobs:
       pdf_artifact:   ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_pdf }}
       can-fail:       'true'
       miktex_image:   ${{ inputs.miktex_image }}
+      update:         ${{ inputs.miktex_update }}
 
   PublishToGitHubPages:
     uses: pyTooling/Actions/.github/workflows/PublishToGitHubPages.yml@dev

--- a/.github/workflows/ExtractConfiguration.yml
+++ b/.github/workflows/ExtractConfiguration.yml
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: 🐍 Setup Python ${{ inputs.python_version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/ExtractConfiguration.yml
+++ b/.github/workflows/ExtractConfiguration.yml
@@ -27,7 +27,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       python_version:
         description: 'Python version.'

--- a/.github/workflows/IntermediateCleanUp.yml
+++ b/.github/workflows/IntermediateCleanUp.yml
@@ -27,7 +27,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       sqlite_coverage_artifacts_prefix:
         description: 'Prefix for SQLite coverage artifacts to be removed.'

--- a/.github/workflows/LaTeXDocumentation.yml
+++ b/.github/workflows/LaTeXDocumentation.yml
@@ -27,7 +27,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       latex_artifact:
         description: 'Name of the LaTeX documentation artifact.'

--- a/.github/workflows/LaTeXDocumentation.yml
+++ b/.github/workflows/LaTeXDocumentation.yml
@@ -42,6 +42,11 @@ on:
         required: false
         default: 'pytooling/miktex:sphinx'
         type: string
+      update:
+        description: 'Update MiKTeX packages.'
+        required: false
+        default: 'false'
+        type: string
       processor:
         description: 'Name of the used LaTeX processor.'
         required: false
@@ -79,10 +84,15 @@ jobs:
           investigate: 'true'
 
       - name: ⚙️ Update
+        if: inputs.update == 'true'
         run: |
+          printf -- "Update package database (miktex --admin packages update-package-database) ...\n"
           sudo miktex --admin packages update-package-database
+          printf -- "Update packages (miktex --admin packages update) ...\n"
           sudo miktex --admin packages update
+          printf -- "Update filename database (initexmf --admin --updatefndb) ...\n"
           sudo initexmf --admin --update-fndb
+          printf -- "DONE\n"
 
       - name: 📖 Build LaTeX document using 'pytooling/miktex:sphinx'
         if: inputs.pdf_artifact != ''

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -53,7 +53,7 @@ jobs:
       artifact: ${{ inputs.artifact }}
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
           submodules: true

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -28,7 +28,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       python_version:
         description: 'Python version.'

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -304,7 +304,7 @@ jobs:
           exclude_list =   "${{ inputs.exclude_list }}".strip()
           disable_list =   "${{ inputs.disable_list }}".strip()
 
-          currentMSYS2Version = "3.13"
+          currentMSYS2Version = "3.14"
           currentAlphaVersion = "3.15"
           currentAlphaRelease = "3.15.0-a.4"
 

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -28,7 +28,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       name:
         description: 'Name of the tool.'
@@ -83,12 +83,12 @@ on:
       ubuntu_image:
         description: 'The used GitHub Action image for Ubuntu (x86-64) based jobs.'
         required: false
-        default: 'ubuntu-24.04'
+        default: 'ubuntu-26.04'
         type: string
       ubuntu_arm_image:
         description: 'The used GitHub Action image for Ubuntu (aarch64) based jobs.'
         required: false
-        default: 'ubuntu-24.04-arm'
+        default: 'ubuntu-26.04-arm'
         type: string
       windows_image:
         description: 'The used GitHub Action image for Windows Server (x86-64) based jobs.'

--- a/.github/workflows/Parameters.yml
+++ b/.github/workflows/Parameters.yml
@@ -165,7 +165,7 @@ jobs:
           sleep ${{ inputs.pipeline-delay }}
 
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # The command 'git describe' (used for version) needs the history.
           fetch-depth: 0

--- a/.github/workflows/PrepareJob.yml
+++ b/.github/workflows/PrepareJob.yml
@@ -27,7 +27,7 @@ on:
       ubuntu_image:
         description: 'Name of the Ubuntu image.'
         required: false
-        default: 'ubuntu-24.04'
+        default: 'ubuntu-26.04'
         type: string
       main_branch:
         description: 'Name of the branch containing releases.'
@@ -131,7 +131,7 @@ on:
 jobs:
   Prepare:
     name: Extract Information
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       on_default_branch:   ${{ steps.Classify.outputs.on_default_branch }}
       on_main_branch:      ${{ steps.Classify.outputs.on_main_branch }}

--- a/.github/workflows/PrepareJob.yml
+++ b/.github/workflows/PrepareJob.yml
@@ -163,7 +163,7 @@ jobs:
           sleep ${{ inputs.pipeline-delay }}
 
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # The command 'git describe' (used for version) needs the history.
           fetch-depth: 0

--- a/.github/workflows/PublishCoverageResults.yml
+++ b/.github/workflows/PublishCoverageResults.yml
@@ -27,7 +27,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       coverage_artifacts_pattern:
         required: false

--- a/.github/workflows/PublishCoverageResults.yml
+++ b/.github/workflows/PublishCoverageResults.yml
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
           submodules: true
@@ -199,7 +199,7 @@ jobs:
           retention-days: 1
 
       - name: 📊 Publish code coverage at CodeCov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         id: codecov
         if: inputs.codecov == 'true'
         continue-on-error: true

--- a/.github/workflows/PublishOnPyPI.yml
+++ b/.github/workflows/PublishOnPyPI.yml
@@ -28,7 +28,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       python_version:
         description: 'Python version.'

--- a/.github/workflows/PublishReleaseNotes.yml
+++ b/.github/workflows/PublishReleaseNotes.yml
@@ -27,7 +27,7 @@ on:
       ubuntu_image:
         description: 'Name of the Ubuntu image.'
         required: false
-        default: 'ubuntu-24.04'
+        default: 'ubuntu-26.04'
         type: string
       release_branch:
         description: 'Name of the branch containing releases.'

--- a/.github/workflows/PublishReleaseNotes.yml
+++ b/.github/workflows/PublishReleaseNotes.yml
@@ -132,7 +132,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # The command 'git describe' (used for version) needs the history.
           fetch-depth: 0

--- a/.github/workflows/PublishTestResults.yml
+++ b/.github/workflows/PublishTestResults.yml
@@ -28,7 +28,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       unittest_artifacts_pattern:
         required: false

--- a/.github/workflows/PublishTestResults.yml
+++ b/.github/workflows/PublishTestResults.yml
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: 📥 Download Artifacts
         uses: pyTooling/download-artifact@v8
@@ -144,7 +144,7 @@ jobs:
           reporter: java-junit
 
       - name: 📊 Publish unittest results at CodeCov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         id: codecov
         if: inputs.codecov == 'true'
         continue-on-error: true

--- a/.github/workflows/PublishToGitHubPages.yml
+++ b/.github/workflows/PublishToGitHubPages.yml
@@ -28,7 +28,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       doc:
         description: 'Name of the documentation artifact.'

--- a/.github/workflows/SphinxDocumentation.yml
+++ b/.github/workflows/SphinxDocumentation.yml
@@ -86,7 +86,7 @@ jobs:
     if: inputs.html_artifact != ''
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
           submodules: true
@@ -145,7 +145,7 @@ jobs:
     if: inputs.latex_artifact != ''
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
           submodules: true

--- a/.github/workflows/SphinxDocumentation.yml
+++ b/.github/workflows/SphinxDocumentation.yml
@@ -27,7 +27,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       python_version:
         description: 'Python version.'

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -28,7 +28,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       python_version:
         description: 'Python version.'

--- a/.github/workflows/StaticTypeCheck.yml
+++ b/.github/workflows/StaticTypeCheck.yml
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: 🐍 Setup Python ${{ inputs.python_version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/TagReleaseCommit.yml
+++ b/.github/workflows/TagReleaseCommit.yml
@@ -28,7 +28,7 @@ on:
       ubuntu_image:
         description: 'Name of the Ubuntu image.'
         required: false
-        default: 'ubuntu-24.04'
+        default: 'ubuntu-26.04'
         type: string
       version:
         description: 'Version used as tag name.'

--- a/.github/workflows/UnitTesting.yml
+++ b/.github/workflows/UnitTesting.yml
@@ -191,7 +191,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
           submodules: true

--- a/.github/workflows/VerifyDocs.yml
+++ b/.github/workflows/VerifyDocs.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: ⏬ Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: 🐍 Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/VerifyDocs.yml
+++ b/.github/workflows/VerifyDocs.yml
@@ -28,7 +28,7 @@ on:
       ubuntu_image_version:
         description: 'Ubuntu image version.'
         required: false
-        default: '24.04'
+        default: '26.04'
         type: string
       python_version:
         description: 'Python version.'

--- a/.github/workflows/_Checking_AvailableRunners.yml
+++ b/.github/workflows/_Checking_AvailableRunners.yml
@@ -14,19 +14,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {icon: '🐧', name: 'Ubuntu 22.04 (x86-64)',  image: 'ubuntu-22.04',     shell: 'bash', can-fail: false}
-          - {icon: '🐧', name: 'Ubuntu 24.04 (x86-64)',  image: 'ubuntu-24.04',     shell: 'bash', can-fail: false}  # latest
-          - {icon: '🍎', name: 'macOS-14 (x86-64)',      image: 'macos-14-large',   shell: 'bash', can-fail: true }  # not in free plan
-###       - {icon: '🍎', name: 'macOS-15 (x86-64)',      image: 'macos-15-large',   shell: 'bash', can-fail: true }  # same as -intel; not in free plan
-          - {icon: '🍎', name: 'macOS-15 (x86-64)',      image: 'macos-15-intel',   shell: 'bash', can-fail: false}
-          - {icon: '🍏', name: 'macOS-14 (aarch64)',     image: 'macos-14',         shell: 'bash', can-fail: false}  # latest
-          - {icon: '🍏', name: 'macOS-15 (aarch64)',     image: 'macos-15',         shell: 'bash', can-fail: false}
-          - {icon: '🪟', name: 'Windows Server 2022',    image: 'windows-2022',     shell: 'bash', can-fail: false}
-          - {icon: '🪟', name: 'Windows Server 2025',    image: 'windows-2025',     shell: 'bash', can-fail: false}  # latest
-        # Third party images by ARM for aarch64
-          - {icon: '⛄', name: 'Ubuntu 22.04 (aarch64)', image: 'ubuntu-22.04-arm', shell: 'bash', can-fail: false}
-          - {icon: '⛄', name: 'Ubuntu 24.04 (aarch64)', image: 'ubuntu-24.04-arm', shell: 'bash', can-fail: false}
-          - {icon: '🏢', name: 'Windows 11 (arch64)',    image: 'windows-11-arm',   shell: 'bash', can-fail: false}
+          # https://github.com/actions/runner-images#available-images
+          - {icon: '🐧', name: 'Ubuntu 22.04 (x86-64)',       image: 'ubuntu-22.04',     shell: 'bash', can-fail: false}
+          - {icon: '🐧', name: 'Ubuntu 24.04 (x86-64)',       image: 'ubuntu-24.04',     shell: 'bash', can-fail: false}  # latest
+          - {icon: '🐧', name: 'Ubuntu 26.04 (x86-64)',       image: 'ubuntu-26.04',     shell: 'bash', can-fail: false}
+          - {icon: '🐧', name: 'Ubuntu 24.04 (x86-64 slime)', image: 'ubuntu-slim',      shell: 'bash', can-fail: false}
+          - {icon: '⛄', name: 'Ubuntu 22.04 (aarch64)',      image: 'ubuntu-22.04-arm', shell: 'bash', can-fail: false}
+          - {icon: '⛄', name: 'Ubuntu 24.04 (aarch64)',      image: 'ubuntu-24.04-arm', shell: 'bash', can-fail: false}
+          - {icon: '⛄', name: 'Ubuntu 26.04 (aarch64)',      image: 'ubuntu-26.04-arm', shell: 'bash', can-fail: false}
+          - {icon: '🍎', name: 'macOS-14 (x86-64)',           image: 'macos-14-large',   shell: 'bash', can-fail: true }  # not in free plan
+###       - {icon: '🍎', name: 'macOS-15 (x86-64)',           image: 'macos-15-large',   shell: 'bash', can-fail: true }  # same as -intel; not in free plan
+          - {icon: '🍎', name: 'macOS-15 (x86-64)',           image: 'macos-15-intel',   shell: 'bash', can-fail: false}  # latest
+          - {icon: '🍎', name: 'macOS-26 (x86-64)',           image: 'macos-26-intel',   shell: 'bash', can-fail: false}
+          - {icon: '🍏', name: 'macOS-14 (aarch64)',          image: 'macos-14',         shell: 'bash', can-fail: false}
+          - {icon: '🍏', name: 'macOS-15 (aarch64)',          image: 'macos-15',         shell: 'bash', can-fail: false}  # latest
+          - {icon: '🍏', name: 'macOS-26 (aarch64)',          image: 'macos-26',         shell: 'bash', can-fail: false}
+          - {icon: '🪟', name: 'Windows Server 2022',         image: 'windows-2022',     shell: 'bash', can-fail: false}
+          - {icon: '🪟', name: 'Windows Server 2025',         image: 'windows-2025',     shell: 'bash', can-fail: false}  # latest
+          - {icon: '🏢', name: 'Windows 11 (arch64)',         image: 'windows-11-arm',   shell: 'bash', can-fail: false}
 
     defaults:
       run:

--- a/.github/workflows/_Checking_CleanupArtifacts.yml
+++ b/.github/workflows/_Checking_CleanupArtifacts.yml
@@ -36,7 +36,7 @@ jobs:
     name: Package generation
     needs:
       - Params
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Package creation
         run: printf "%s\n" "Package" >> package.txt

--- a/.github/workflows/_Checking_JobTemplates.yml
+++ b/.github/workflows/_Checking_JobTemplates.yml
@@ -204,7 +204,7 @@ jobs:
       - UnitTestingParams
       - Documentation
     with:
-      document:       'Actions'
+      document:       'myPackage'
       latex_artifact: ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_latex }}
       pdf_artifact:   ${{ fromJson(needs.UnitTestingParams.outputs.artifact_names).documentation_pdf }}
 

--- a/.github/workflows/_Checking_Nightly.yml
+++ b/.github/workflows/_Checking_Nightly.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   Build:
     name: Build something
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
       - name: 🖉 Build 1

--- a/.github/workflows/_Checking_Parameters.yml
+++ b/.github/workflows/_Checking_Parameters.yml
@@ -58,7 +58,7 @@ jobs:
   Params_Check_Default:
     needs:
       - Params_Default
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     defaults:
       run:
         shell: python
@@ -73,7 +73,7 @@ jobs:
           expected-python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
           expected-systems:         '["ubuntu", "ubuntu-arm", "windows", "windows-arm", "macos", "macos-arm"]'
           expected-exclude-jobs:    '["windows-arm:3.10"]'
-          expected-include-jobs:    '["mingw64:3.13", "ucrt64:3.13"]'
+          expected-include-jobs:    '["mingw64:3.14", "ucrt64:3.14"]'
           generated-default-version: ${{ needs.Params_Default.outputs.python_version }}
           generated-jobmatrix:       ${{ needs.Params_Default.outputs.python_jobs }}
 
@@ -86,7 +86,7 @@ jobs:
   Params_Check_PythonVersions:
     needs:
       - Params_PythonVersions
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     defaults:
       run:
         shell: python
@@ -101,14 +101,14 @@ jobs:
           expected-python-versions: '["3.12", "3.13", "pypy-3.10", "pypy-3.11"]'
           expected-systems:         '["ubuntu", "ubuntu-arm", "windows", "windows-arm", "macos", "macos-arm"]'
           expected-exclude-jobs:    '["windows-arm:pypy-3.10", "windows-arm:pypy-3.11"]'
-          expected-include-jobs:    '["mingw64:3.13", "ucrt64:3.13"]'
+          expected-include-jobs:    '["mingw64:3.14", "ucrt64:3.14"]'
           generated-default-version: ${{ needs.Params_PythonVersions.outputs.python_version }}
           generated-jobmatrix:       ${{ needs.Params_PythonVersions.outputs.python_jobs }}
 
   Params_Check_Systems:
     needs:
       - Params_Systems
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     defaults:
       run:
         shell: python
@@ -123,14 +123,14 @@ jobs:
           expected-python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
           expected-systems:         '["windows"]'
           expected-exclude-jobs:    '[]'
-          expected-include-jobs:    '["mingw32:3.13", "mingw64:3.13"]'
+          expected-include-jobs:    '["mingw32:3.14", "mingw64:3.14"]'
           generated-default-version: ${{ needs.Params_Systems.outputs.python_version }}
           generated-jobmatrix:       ${{ needs.Params_Systems.outputs.python_jobs }}
 
   Params_Check_Include:
     needs:
       - Params_Include
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     defaults:
       run:
         shell: python
@@ -152,7 +152,7 @@ jobs:
   Params_Check_Exclude:
     needs:
       - Params_Exclude
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     defaults:
       run:
         shell: python
@@ -174,7 +174,7 @@ jobs:
   Params_Check_Disable:
     needs:
       - Params_Disable
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     defaults:
       run:
         shell: python
@@ -196,7 +196,7 @@ jobs:
   Params_Check_All:
     needs:
       - Params_All
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     defaults:
       run:
         shell: python

--- a/.github/workflows/_Checking_Parameters.yml
+++ b/.github/workflows/_Checking_Parameters.yml
@@ -64,7 +64,7 @@ jobs:
         shell: python
     steps:
       - name: Checkout repository to access local Action
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checking job matrix from 'Params_Default'
         uses: ./.github/actions/CheckJobMatrix
@@ -92,7 +92,7 @@ jobs:
         shell: python
     steps:
       - name: Checkout repository to access local Action
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checking job matrix from 'Params_PythonVersions'
         uses: ./.github/actions/CheckJobMatrix
@@ -114,7 +114,7 @@ jobs:
         shell: python
     steps:
       - name: Checkout repository to access local Action
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checking job matrix from 'Params_Systems'
         uses: ./.github/actions/CheckJobMatrix
@@ -136,7 +136,7 @@ jobs:
         shell: python
     steps:
       - name: Checkout repository to access local Action
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checking job matrix from 'Params_Include'
         uses: ./.github/actions/CheckJobMatrix
@@ -158,7 +158,7 @@ jobs:
         shell: python
     steps:
       - name: Checkout repository to access local Action
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checking job matrix from 'Params_Exclude'
         uses: ./.github/actions/CheckJobMatrix
@@ -180,7 +180,7 @@ jobs:
         shell: python
     steps:
       - name: Checkout repository to access local Action
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checking job matrix from 'Params_Disable'
         uses: ./.github/actions/CheckJobMatrix
@@ -202,7 +202,7 @@ jobs:
         shell: python
     steps:
       - name: Checkout repository to access local Action
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Checking job matrix from 'Params_All'
         uses: ./.github/actions/CheckJobMatrix

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Find further usage cases in the following list of projects:
 
 ## License
 
-This Python package (source code) licensed under [Apache License 2.0](LICENSE.md).
+This Python package (source code) is licensed under [Apache License 2.0](LICENSE.md).
 The accompanying documentation is licensed under [Creative Commons - Attribution 4.0 (CC-BY 4.0)](doc/Doc-License.rst).
 
 ---

--- a/doc/Glossary.rst
+++ b/doc/Glossary.rst
@@ -39,7 +39,7 @@ Glossary
 
      :Source Code:   `github.com/GeekyEggo/delete-artifact/ <https://github.com/GeekyEggo/delete-artifact/>`__
      :Marketplace:   `github.com/marketplace/actions/delete-artifact/ <https://github.com/marketplace/actions/delete-artifact/>`__
-     :README:        `github.com/GeekyEggo/delete-artifact ⭢ README.md <https://github.com/GeekyEggo/delete-artifact/blob/main/README.md>`__
+     :README:        `github.com/GeekyEggo/delete-artifact → README.md <https://github.com/GeekyEggo/delete-artifact/blob/main/README.md>`__
 
    docstr_coverage
      Docstring coverage analysis and rating for Python.
@@ -118,7 +118,7 @@ Glossary
 
      :Source Code:   `github.com/dorny/test-reporter/ <https://github.com/dorny/test-reporter/>`__
      :Marketplace:   `github.com/marketplace/actions/test-reporter/ <https://github.com/marketplace/actions/test-reporter/>`__
-     :README:        `github.com/dorny/test-reporter ⭢ README.md <https://github.com/dorny/test-reporter/blob/main/README.md>`__
+     :README:        `github.com/dorny/test-reporter → README.md <https://github.com/dorny/test-reporter/blob/main/README.md>`__
 
    twine
      Utilities for interacting with PyPI.

--- a/doc/JobTemplate/Release/PublishReleaseNotes.rst
+++ b/doc/JobTemplate/Release/PublishReleaseNotes.rst
@@ -139,6 +139,8 @@ Additional text from :ref:`JOBTMPL/PublishReleaseNotes/Input/description_footer`
      moved by N levels down.
    ``%%FOOTER%%``
      Replaces the placeholder with the content from :ref:`JOBTMPL/PublishReleaseNotes/Input/description_footer`.
+   ``%%TAG%%``
+     Replaces the placeholder with the ``tag`` parameter provided to the job template.
    ``%%gh_server%%``
      Replaced by the GitHub server URL. |br|
      The value is derived from ``${{ github.server_url }}``.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -119,41 +119,22 @@ modindex_common_prefix = [
 # ==============================================================================
 # Options for LaTeX / PDF output
 # ==============================================================================
-# preamblePath = Path("preamble.tex")
-# try:
-# 	with preamblePath.open("r", encoding="utf-8") as fileHandle:
-# 		latexPreamble = fileHandle.read()
-# except Exception as ex:
-# 	print(f"[ERROR:] While reading '{preamblePath}'.")
-# 	print(ex)
-# 	latexPreamble = ""
-
 latex_engine = "lualatex"
 latex_use_xindy = False
 latex_elements = {
-	"papersize": "a4paper",      # The paper size ('letterpaper' or 'a4paper').
-	"pointsize": "10pt",         # The font size ('10pt', '11pt' or '12pt').
-	"inputenc":   "",            # Let LuaLaTeX handle input encoding
-	"utf8extra":  "",
+	"papersize":   "a4paper",      # The paper size ('letterpaper' or 'a4paper').
+	"pointsize":   "10pt",         # The font size ('10pt', '11pt' or '12pt').
+	"inputenc":    "",             # Let LuaLaTeX handle input encoding
+	"utf8extra":   "",
+	"polyglossia": "",
+	"babel":      r"\usepackage[english]{babel}",
 	"fontenc":    r"\usepackage{fontspec}",  # Disable the default T1 font encoding (Essential for LuaLaTeX)
 	"fontpkg":    dedent("""\
-		\\usepackage{unicode-math}
-
-		% Set the Text Fonts (Libertinus)
-		\\setmainfont{Libertinus Serif}
-		\\setsansfont{Libertinus Sans}
-		\\setmonofont{Libertinus Mono}
-		\\setmathfont{Libertinus Math}
-
-		% Set Symbol font
-		\\usepackage{newunicodechar}
-		\\newfontfamily{\\emojifont}[Renderer=OpenType]{NotoColorEmoji.ttf}
-		\\usepackage{pytooling}
+		\\usepackage[fontfamily=libertinus]{pytooling}
 	"""),
 	"passoptionstopackages": dedent("""\
 		\\PassOptionsToPackage{verbatimvisiblespace=\\ }{sphinx}
 	"""),
-# "preamble":  latexPreamble,  # Additional stuff for the LaTeX preamble.
 # "sphinxsetup": "verbatimvisiblespace=\\textvisiblespace"
 # "figure_align": "htbp",     # Latex figure (float) alignment
 	"makeindex":  r"\usepackage[columns=1]{idxlayout}\makeindex",
@@ -165,10 +146,10 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
 	( master_doc,
-		f"{githubProject}.tex",
-		f"The {githubProject} Documentation",
-		f"Patrick Lehmann",
-		f"manual"
+		f"{pythonProject}.tex",
+		f"The {pythonProject.replace("_", r"\_")} Documentation",
+		 "Patrick Lehmann",
+		 "manual"
 	),
 ]
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -242,15 +242,8 @@ Contributors
 License
 *******
 
-.. only:: html
-
-   This Python package (source code) is licensed under `Apache License 2.0 <Code-License.html>`__. |br|
-   The accompanying documentation is licensed under `Creative Commons - Attribution 4.0 (CC-BY 4.0) <Doc-License.html>`__.
-
-.. only:: latex
-
-   This Python package (source code) is licensed under **Apache License 2.0**. |br|
-   The accompanying documentation is licensed under **Creative Commons - Attribution 4.0 (CC-BY 4.0)**.
+This Python package (source code) is licensed under :ref:`Apache License 2.0 <CODELICENSE>`. |br|
+The accompanying documentation is licensed under :ref:`Creative Commons - Attribution 4.0 (CC-BY 4.0) <DOCLICENSE>`.
 
 
 .. toctree::

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -16,4 +16,4 @@ autoapi >= 2.0.1
 sphinx_design ~= 0.7.0
 sphinx-copybutton >= 0.5.2
 sphinx_autodoc_typehints ~= 3.10
-sphinx_reports ~= 0.10.0
+sphinx_reports ~= 0.11.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,5 +15,5 @@ sphinxcontrib-mermaid ~= 2.0
 autoapi >= 2.0.1
 sphinx_design ~= 0.7.0
 sphinx-copybutton >= 0.5.2
-sphinx_autodoc_typehints ~= 3.5   # 3.9 is conflicting with old sphinx_design and rtd theme due to sphinx<9 and docutils<0.22
+sphinx_autodoc_typehints ~= 3.10
 sphinx_reports ~= 0.10.0

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -5,4 +5,4 @@ Coverage ~= 7.13
 
 # Test Runner
 pytest ~= 9.0
-pytest-cov ~= 7.0
+pytest-cov ~= 7.1

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,7 +1,7 @@
 -r ../../requirements.txt
 
 # Coverage collection
-Coverage ~= 7.13
+Coverage ~= 7.14
 
 # Test Runner
 pytest ~= 9.0


### PR DESCRIPTION
# New Features

* `CompletePipeline`:
  * `miktex_update` allow control for updates in MiKTeX.
* `PublishReleaseNotes`:
  * Replace `%%TAG%%` with the Git tag.

# Changes

* Linux (Ubuntu) based pipeline templates use Ubuntu 26.04 as default image.
* Bumped dependencies:
  * `actions/checkout@v6` &rarr; `actions/checkout@v7`
  * `codecov/codecov-action@v6` &rarr; `codecov/codecov-action@v7`
* Changed displayed Python version for MSYS2 to `3.14`.  
  (This is just a visual.)

# Unit Tests

* Testing for available GitHub Action image has been widened.
* Use Ubuntu 26.04 for Linux tests.


----------
# Related Issues and Pull-Requests

* #228
