### PR TITLE
Fix submodule detection, the CleanupArtifacts NameError and the skippable Bandit scan

### DIFF
--- a/.github/workflows/CheckCodeQuality.yml
+++ b/.github/workflows/CheckCodeQuality.yml
@@ -86,7 +86,6 @@ jobs:
 
       - name: 👮 Bandit
         id: bandit
-        if: inputs.artifact != ''
         run: |
           set +e
 

--- a/.github/workflows/CleanupArtifacts.yml
+++ b/.github/workflows/CleanupArtifacts.yml
@@ -96,7 +96,7 @@ jobs:
               case [prefix, key, postfix] if key in artifactNames:
                 artifacts.append(f"{prefix}{artifactNames[key]}{postfix}")
               case _:
-                printf(f"Name '{name}' not found in JSON dictionary.")
+                print(f"Name '{name}' not found in JSON dictionary.")
 
           print("Artifact to delete:")
           for name in artifacts:
@@ -143,7 +143,7 @@ jobs:
               case [prefix, key, postfix] if key in artifactNames:
                 artifacts.append(f"{prefix}{artifactNames[key]}{postfix}")
               case _:
-                printf(f"Name '{name}' not found in JSON dictionary.")
+                print(f"Name '{name}' not found in JSON dictionary.")
 
           print("Artifact to delete:")
           for name in artifacts:

--- a/.github/workflows/PrepareJob.yml
+++ b/.github/workflows/PrepareJob.yml
@@ -366,9 +366,9 @@ jobs:
           fi
 
           # Submodules
-          if [[ -f .gitsubmodules ]]; then
+          git_modules_file=.gitmodules   # $(git rev-parse --show-toplevel)/.gitmodules
+          if [[ -f "${git_modules_file}" ]]; then
             has_submodules="true"
-            git_modules_file=.gitmodules   # $(git rev-parse --show-toplevel)/.gitmodules
             git_submodule_count="$(grep -Po '(?<=\[submodule \")(.*)(?=\"\])' "${git_modules_file}" | wc -l)"
             git_submodule_names="$(grep -Po '(?<=\[submodule \")(.*)(?=\"\])' "${git_modules_file}" | paste -sd ':' -)"
             git_submodule_paths="$(git config --file "${git_modules_file}" --null --name-only --get-regexp '\.path$' | xargs -0 -n1 git config --file "${git_modules_file}" --get | paste -sd ':' -)"

--- a/.github/workflows/_Checking_CleanupArtifacts.yml
+++ b/.github/workflows/_Checking_CleanupArtifacts.yml
@@ -58,8 +58,10 @@ jobs:
       - Package
     with:
       json: ${{ needs.Params.outputs.artifact_names }}
+      # Deliberate added 'unknown_key' for exception testing.
       artifact-json-ids: >-
         unittesting_xml:-*
+        unknown_key
       # The package artifact is kept on tagged runs, so 'PublishOnPyPI.yml' can still consume it.
       json2: ${{ needs.Params.outputs.artifact_names }}
       condition2: ${{ ! startsWith(github.ref, 'refs/tags') }}


### PR DESCRIPTION
# New Features

* None. Three defect fixes found while cross-checking the documentation against the workflows in #245.

# Changes

* No input, output or default was added, renamed or removed, so `@r7` consumers need no adjustment.
* `CheckCodeQuality.yml`'s `artifact` input is now unused. It is kept declared, because removing an input from a stable release branch breaks every consumer that passes it — `CompletePipeline` does. See the note at the bottom.

# Bug Fixes

* **`PrepareJob.yml`: submodules were never detected.** The check tested for a file named `.gitsubmodules`; Git's file is `.gitmodules`. `has_submodules` was therefore always `'false'`, and `git_submodule_count`, `git_submodule_names` and `git_submodule_paths` kept their initial empty values — for every repository, since the workflow was introduced.

  The block already had the correct name in a local variable one line below:

  ```bash
  if [[ -f .gitsubmodules ]]; then
    has_submodules="true"
    git_modules_file=.gitmodules   # <- correct name, one line too late
  ```

  The variable is now assigned first and used for the test.

  Verified against a scratch repository with two submodules:

  ```
  has_submodules=true
  count=2
  names=libA:libB
  paths=deps/libA:deps/libB
  ```

  and `has_submodules=false` once `.gitmodules` is removed.

  Nothing consumes these four outputs today, which is why nobody hit it. It matters as soon as a pipeline wants to check out submodules conditionally.

* **`CleanupArtifacts.yml`: an unknown artifact ID raised `NameError`.** Both compute steps call `printf(...)` in their `case _:` fallback, but the step runs `shell: python`, where `printf` is not a function:

  ```python
  case _:
    printf(f"Name '{name}' not found in JSON dictionary.")
  ```

  So an `artifact-json-ids` entry that is not a key of the JSON dictionary — a typo, or a key removed from `Parameters.yml` while a consumer still lists it — aborted the step instead of reporting the name. That is precisely the case the branch exists for.

  Reproduced against the previous revision of the step:

  ```
  BEFORE the fix -> exit code: 1
      NameError: name 'printf' is not defined. Did you mean: 'print'?
  ```

  and against this one:

  ```
  Name 'typo_key' not found in JSON dictionary.
  Artifact to delete:
    pyX-UnitTestReportSummary-XML-*
    pyX-Packages
  ```

  The second run also confirms that a `#`-commented entry is still skipped and that the prefix/postfix forms still resolve.

* **`CheckCodeQuality.yml`: the security scan could be skipped silently.** The `Bandit` step was guarded by `if: inputs.artifact != ''`, although the step writes its report to a fixed path (`report/bandit/report.xml`) and never used that parameter. An empty artifact name skipped the scan, while the job installed bandit, ran to the end and reported **success** — a green security check that scanned nothing.

  `artifact` is declared `required: true`, but GitHub does not enforce required inputs that arrive as an empty string from an expression, which is how a consumer would realistically pass one.

  The guard is removed. The scan now runs whenever the job runs, i.e. whenever `bandit: 'true'`.

# Documentation

* None here. #245 documents all three as observed behaviour with `.. attention::` notes; those notes are removed in that pull-request's branch, since this one makes them obsolete. The two pull-requests are independent, but both should land — see the note below.

# Unit Tests

* **`_Checking_CleanupArtifacts.yml` now passes an `unknown_key` entry**, so the `case _:` branch is exercised by the verification pipeline rather than only by a typo in production.

* The `PrepareJob` submodule logic was executed offline against a scratch repository, in both states (`.gitmodules` present and absent) — output quoted above. The Actions repository itself has no submodules, so its own pipeline cannot cover the positive case.

* Both changed shell scripts pass `bash -n`, and all four changed workflows parse as YAML.

* The `CheckCodeQuality` change is covered by this repository's own pipeline: `_Checking_JobTemplates.yml` instantiates the template, and the *Bandit* findings in `myPackage`/`myFramework` are deliberate, so the step must run and report them.

----------
# Review (2026-08-03)

* **No description of past defects in the source.** The three explanatory comments I had added — why `.gitsubmodules` was wrong, why the `if:` on the *Bandit* step is gone, what the `unknown_key` entry exercises — are removed. A fix belongs in the commit message and in this description; the code should read as if the defect never existed. The comment in `_Checking_CleanupArtifacts.yml` is reduced to the reviewer's one-liner, `# Deliberate added 'unknown_key' for exception testing.`

  The diff is now four hunks, all of them the actual change.

* The `unknown_key` regression entry is **kept**, pending the reviewer's decision. It does not test for a typo: it covers the `case _:` branch, which is documented behaviour (*"A key that is not present in the dictionary is reported and skipped"*) and is reachable without any typo — a key removed from `Parameters.yml` while a consumer on `@r7` still lists it. Because `shell: python` aborts the whole step, an unknown ID meant *no* artifact of that set was deleted, not "one entry skipped". One line to drop if unwanted.

* The submodule block was re-verified after the edit, since removing the comments touched that hunk: `has_submodules=true count=2 names=libA:libB paths=deps/libA:deps/libB` against a scratch repository with two submodules, `false` with empty outputs once `.gitmodules` is removed.

----------
# Related Issues and Pull-Requests

* Findings A11, A12 and A13, all recorded while writing #245.
* Independent of #244 (v7.14.2) and #245 (documentation rework); no file overlaps.

> [!NOTE]
> `CheckCodeQuality.yml`'s `artifact` input is now referenced nowhere. It is declared `required: true`, so it cannot be dropped without breaking consumers that pass it on `@r7`. Two options for a later major release: remove it, or give it a purpose by uploading the bandit XML report under that name. Left as is here, because either choice is an interface decision rather than a bug fix.

